### PR TITLE
Hi, I'm Jules, your AI coding agent. I've made the following changes:

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
     "target_weights": {
         "BTC_SPOT": 0.65,
-        "BTC_LONG5X": 0.11,
-        "BTC_SHORT5X": 0.24
+        "BTC_PERP_LONG": 0.11,
+        "BTC_PERP_SHORT": 0.24
     }
 }

--- a/config/backtest_params_example.json
+++ b/config/backtest_params_example.json
@@ -1,8 +1,8 @@
 {
   "target_weights": {
     "BTC_SPOT": 0.65,
-    "BTC_LONG5X": 0.11,
-    "BTC_SHORT5X": 0.24
+    "BTC_PERP_LONG": 0.11,
+    "BTC_PERP_SHORT": 0.24
   },
   "rebalance_threshold": 0.01,
   "initial_portfolio_value_usdt": 1000.0,
@@ -16,7 +16,7 @@
   "margin_usage_safe_mode_exit_threshold": 0.5,
   "safe_mode_target_weights": {
     "BTC_SPOT": 0.8,
-    "BTC_LONG5X": 0.05,
-    "BTC_SHORT5X": 0.15
+    "BTC_PERP_LONG": 0.05,
+    "BTC_PERP_SHORT": 0.15
   }
 }

--- a/config/best_config_v1000.json
+++ b/config/best_config_v1000.json
@@ -58,8 +58,8 @@
     "rebalance_threshold": 0.014,
     "target_weights_normal": {
       "BTC_SPOT": 0.75,
-      "BTC_LONG5X": 0.05,
-      "BTC_SHORT5X": 0.20
+      "BTC_PERP_LONG": 0.05,
+      "BTC_PERP_SHORT": 0.20
     },
     "circuit_breaker_config": {
       "enabled": true,
@@ -74,8 +74,8 @@
       "exit_threshold": 0.6,
       "target_weights_safe": {
         "BTC_SPOT": 0.80,
-        "BTC_LONG5X": 0.02,
-        "BTC_SHORT5X": 0.18,
+        "BTC_PERP_LONG": 0.02,
+        "BTC_PERP_SHORT": 0.18,
         "USDT": 0.15
       }
     },

--- a/config/unified_config.example.json
+++ b/config/unified_config.example.json
@@ -34,13 +34,13 @@
         "high": 0.8
       },
       {
-        "path": "target_weights_normal.{main_asset_symbol}_LONG5X",
+        "path": "target_weights_normal.{main_asset_symbol}_PERP_LONG",
         "type": "float",
         "low": 0.0,
         "high": 0.4
       },
       {
-        "path": "target_weights_normal.{main_asset_symbol}_SHORT5X",
+        "path": "target_weights_normal.{main_asset_symbol}_PERP_SHORT",
         "type": "float",
         "low": 0.0,
         "high": 0.4
@@ -73,8 +73,8 @@
     "rebalance_threshold": 0.02,
     "target_weights_normal": {
       "BTC_SPOT": 0.65,
-      "BTC_LONG5X": 0.11,
-      "BTC_SHORT5X": 0.24
+      "BTC_PERP_LONG": 0.11,
+      "BTC_PERP_SHORT": 0.24
     },
     "circuit_breaker_config": {
       "enabled": true,
@@ -89,8 +89,8 @@
       "exit_threshold": 0.60,
       "target_weights_safe": {
         "BTC_SPOT": 0.75,
-        "BTC_LONG5X": 0.05,
-        "BTC_SHORT5X": 0.05,
+        "BTC_PERP_LONG": 0.05,
+        "BTC_PERP_SHORT": 0.05,
         "USDT": 0.15
       }
     },

--- a/src/prosperous_bot/exchange_gate.py
+++ b/src/prosperous_bot/exchange_gate.py
@@ -75,11 +75,22 @@ class ExchangeAPI:
         )
         return await self._safe_call(self.spot_api.create_order, order)
 
-    async def create_futures_order(self, contract, side, qty, reduce_only=False):
+    async def create_futures_order(
+        self,
+        contract: str,
+        order_type: str,           # OPEN_LONG, CLOSE_LONG, OPEN_SHORT, CLOSE_SHORT
+        qty: float,
+    ):
+        if order_type not in {"OPEN_LONG", "CLOSE_LONG", "OPEN_SHORT", "CLOSE_SHORT"}:
+            raise ValueError(f"Unsupported order_type {order_type}")
+
+        size        =  qty if order_type.endswith("_LONG")  else -qty
+        reduce_only =  order_type.startswith("CLOSE_")
+
         fut = gate_api.FuturesOrder(
-            contract=contract,
-            size=qty if side == "long" else -qty,
-            reduce_only=bool(reduce_only),
+            contract    = contract,
+            size        = size,
+            reduce_only = reduce_only,
         )
         return await self._safe_call(self.futures_api.create_futures_order, "usdt", fut)
 

--- a/tests/test_exchange.py
+++ b/tests/test_exchange.py
@@ -36,9 +36,8 @@ async def test_create_futures_order(exch, mocker):
     )
     res = await exch.create_futures_order(
         contract="BTC_USDT",
-        side="long",
+        order_type="OPEN_LONG",
         qty=1,
-        reduce_only=False,
     )
     assert res["status"] == "open"
     # убедимся, что вызвали API ровно один раз

--- a/tests/test_portfolio.py
+++ b/tests/test_portfolio.py
@@ -17,5 +17,5 @@ async def test_get_value_distribution_usdt(mocker):
     pm = PortfolioManager(spot_api, fut_api)
     values = await pm.get_value_distribution_usdt(p_spot=50000, p_contract=250)
     assert isinstance(values, dict)
-    assert all(k in values for k in ("BTC_SPOT", "BTC_SHORT5X", "BTC_LONG5X"))
+    assert all(k in values for k in ("BTC_SPOT", "BTC_PERP_SHORT", "BTC_PERP_LONG"))
     assert all(isinstance(v, float) for v in values.values())

--- a/tests/test_rebalance.py
+++ b/tests/test_rebalance.py
@@ -18,8 +18,8 @@ class MockPortfolio:
 async def test_build_orders_pct_logic():
     portfolio = MockPortfolio({
         "BTC_SPOT": 6400,      # ~62.14%
-        "BTC_SHORT5X": 2700,   # ~26.22%
-        "BTC_LONG5X": 1200     # ~11.65%
+        "BTC_PERP_SHORT": 2700,   # ~26.22%
+        "BTC_PERP_LONG": 1200     # ~11.65%
     })
 
     engine = RebalanceEngine(portfolio, threshold_pct=0.01)

--- a/tests/test_rebalance_engine.py
+++ b/tests/test_rebalance_engine.py
@@ -49,8 +49,8 @@ class DummyExchange:
 @pytest.mark.asyncio
 async def test_build_orders_threshold():
     """RebalanceEngine should create orders only when diff exceeds threshold"""
-    target = {"BTC_SPOT": 0.65, "BTC_SHORT5X": 0.24, "BTC_LONG5X": 0.11}
-    current = {"BTC_SPOT": 0.60, "BTC_SHORT5X": 0.25, "BTC_LONG5X": 0.15}
+    target = {"BTC_SPOT": 0.65, "BTC_PERP_SHORT": 0.24, "BTC_PERP_LONG": 0.11}
+    current = {"BTC_SPOT": 0.60, "BTC_PERP_SHORT": 0.25, "BTC_PERP_LONG": 0.15}
     port = DummyPortfolio(current, nav=1000)
     engine = RebalanceEngine(
         portfolio=port,


### PR DESCRIPTION
Standardize PERP keys, implement notional weights, and add order-type for hedge futures.

This commit addresses inconsistencies in asset key naming, weight calculation, and order creation for hedged futures.

Key changes:
- Standardized asset keys from `*_LONG5X`/`*_SHORT5X` to `*_PERP_LONG`/`*_PERP_SHORT` across the codebase, including configuration files and tests.
- Modified `portfolio_manager.py` to calculate notional value for positions using `abs(size) * p_contract` for more accurate weight distribution.
- Updated `rebalance_backtester.py` to use the new asset keys and map BUY/SELL actions to `OPEN_LONG/CLOSE_LONG` and `OPEN_SHORT/CLOSE_SHORT` order types for futures.
- Enhanced `exchange_gate.py`'s `create_futures_order` function to accept an `order_type` parameter (e.g., `OPEN_LONG`) and automatically set `reduce_only` based on this type.

These changes ensure that your portfolio metrics are calculated correctly and that orders sent to the exchange align with the intended hedged UM trading mode.