### PR TITLE
Refactor: Parameterize base currency in PortfolioManager

### DIFF
--- a/src/prosperous_bot/portfolio_manager.py
+++ b/src/prosperous_bot/portfolio_manager.py
@@ -3,21 +3,22 @@ import asyncio
 class PortfolioManager:
     """Simplified portfolio manager used in unit/property tests."""
 
-    def __init__(self, spot_api, futures_api):
+    def __init__(self, spot_api, futures_api, base_currency: str = "BTC"):
         self.spot_api = spot_api
         self.futures_api = futures_api
+        self._base = base_currency
 
     async def get_value_distribution_usdt(self, p_spot: float, p_contract: float | None = None):
         acc_raw = self.spot_api.spot.get_account_detail()
         accounts = await acc_raw if asyncio.iscoroutine(acc_raw) else acc_raw
 
-        spot_qty = sum(float(a.available) for a in accounts if getattr(a, "currency", "") == "BTC")
+        spot_qty = sum(float(a.available) for a in accounts if getattr(a, "currency", "") == self._base)
         spot_val = spot_qty * p_spot
 
         pos_raw = self.futures_api.futures.list_positions()
         positions = await pos_raw if asyncio.iscoroutine(pos_raw) else pos_raw
 
-        long_val = short_val = 0.0
+        long_val = short_val = 0.0                      # notional in USDT
         for p in positions:
             size = float(p.size)
             # notional = abs(size) × contract-price (fallback→margin)
@@ -30,12 +31,12 @@ class PortfolioManager:
         # Recalculate total based on new notional values for accurate weighting
         total = spot_val + long_val + short_val
         if total == 0:  # Avoid division by zero
-            return {"BTC_SPOT": 0.0, "BTC_PERP_LONG": 0.0, "BTC_PERP_SHORT": 0.0}
+            return {f"{self._base}_SPOT": 0.0, f"{self._base}_PERP_LONG": 0.0, f"{self._base}_PERP_SHORT": 0.0}
 
         return {
-            "BTC_SPOT":       spot_val / total,
-            "BTC_PERP_LONG":  long_val / total,
-            "BTC_PERP_SHORT": short_val / total,
+            f"{self._base}_SPOT"       : spot_val / total,
+            f"{self._base}_PERP_LONG"  : long_val / total,
+            f"{self._base}_PERP_SHORT" : short_val / total,
         }
 
     def get_value_distribution_sync(self, p_spot: float, p_contract: float):


### PR DESCRIPTION
Introduces `self._base` in `PortfolioManager` to allow dynamic construction of dictionary keys for value distribution. This addresses the issue of hardcoded "BTC" keys.

Changes:
- Added `base_currency` parameter to `__init__` (defaulting to "BTC") and stores it as `self._base`.
- Updated spot quantity calculation to filter by `self._base`.
- Added comment "# notional in USDT" to `long_val = short_val = 0.0`.
- Modified dictionary keys in `get_value_distribution_usdt` to use f-strings with `self._base` for both the main return value and the zero-total fallback case.