### PR TITLE
feat: Implement parametric symbols in configuration

### DIFF
--- a/config/unified_config.example.json
+++ b/config/unified_config.example.json
@@ -72,9 +72,9 @@
     "min_rebalance_interval_minutes": 5,
     "rebalance_threshold": 0.005,
     "target_weights_normal": {
-      "BTC_SPOT": 0.65,
-      "BTC_PERP_LONG": 0.11,
-      "BTC_PERP_SHORT": 0.24
+      "{main_asset_symbol}_SPOT": 0.65,
+      "{main_asset_symbol}_PERP_LONG": 0.11,
+      "{main_asset_symbol}_PERP_SHORT": 0.24
     },
     "circuit_breaker_config": {
       "enabled": true,
@@ -88,9 +88,9 @@
       "entry_threshold": 0.70,
       "exit_threshold": 0.60,
       "target_weights_safe": {
-        "BTC_SPOT": 0.75,
-        "BTC_PERP_LONG": 0.05,
-        "BTC_PERP_SHORT": 0.05,
+        "{main_asset_symbol}_SPOT": 0.75,
+        "{main_asset_symbol}_PERP_LONG": 0.05,
+        "{main_asset_symbol}_PERP_SHORT": 0.05,
         "USDT": 0.15
       }
     },


### PR DESCRIPTION
This commit introduces placeholder substitution for asset symbols in the configuration files and relevant Python scripts.

Changes include:
- Modified `config/unified_config.example.json` to use `{main_asset_symbol}` placeholders for asset-specific keys (e.g., in `target_weights_normal`, `safe_mode_config`).
- Updated `src/prosperous_bot/rebalance_backtester.py` to add a `_subst_symbol` helper function and integrate it into `run_backtest` to dynamically replace placeholders with the actual `main_asset_symbol` from parameters.
- Updated `src/prosperous_bot/rebalance_engine.py` to include the same `_subst_symbol` logic in its `__init__` method for consistent behavior when the engine is used directly.

These changes allow the bot to be configured for different main assets (e.g., DOGE) without hardcoding symbol names, addressing the issue of incorrect rebalancing when non-BTC assets are used.