### PR TITLE
feat: Implement flexible data loading and auto date ranging

### DIFF
--- a/config/unified_config.example.json
+++ b/config/unified_config.example.json
@@ -95,8 +95,8 @@
       }
     },
     "data_settings": {
-      "csv_file_path": "graphs/BTCUSDT_data.csv",
-      "signals_csv_path": "graphs/BTCUSDT_signals.csv",
+      "csv_file_path": "graphs/{main_asset_symbol}USDT_data.csv",
+      "signals_csv_path": "graphs/{main_asset_symbol}USDT_signals.csv",
       "timestamp_col": "timestamp",
       "ohlc_cols": {
         "open": "open",
@@ -108,8 +108,8 @@
       "price_col_for_rebalance": "close"
     },
     "date_range": {
-      "start_date": "2025-04-26T22:45:00Z",
-      "end_date": "2025-05-26T22:40:59Z"
+      "start_date": "auto",
+      "end_date": "auto"
     },
     "logging_level": "INFO",
     "report_path_prefix": "./reports/"


### PR DESCRIPTION
This commit introduces several enhancements to the backtester configuration and functionality:

1.  **Configurable File Paths**:
    *   `unified_config.example.json` now uses `{main_asset_symbol}` placeholders in `csv_file_path` and `signals_csv_path`.
    *   The `_subst_symbol` function in `rebalance_backtester.py` has been updated to replace `*USDT` patterns with the specific asset symbol (e.g., `DOGEUSDT`), allowing dynamic loading of CSV files based on the `main_asset_symbol`.

2.  **Automatic Date Range Detection**:
    *   `unified_config.example.json` now defaults `start_date` and `end_date` to `"auto"`.
    *   `rebalance_backtester.py` implements logic to automatically set the backtest date range to the full range of available data in the CSV if `"auto"` is specified. It also adjusts configured dates to fit within the CSV's range if they fall outside, logging a warning.

These changes allow for a single configuration file to be used for backtesting different trading pairs and ensure that backtests cover the entire available historical data by default.