### PR TITLE
Fix: Apply patches to test_portfolio and test_rebalance_backtester_le…

### DIFF
--- a/tests/test_portfolio.py
+++ b/tests/test_portfolio.py
@@ -96,7 +96,7 @@ async def test_get_value_distribution_with_leverage(mocker):
         assert actual_values_async_spot_only[key] == pytest.approx(expected_distribution_spot_only[key]), \
             f"Async mismatch for {key} (spot only)"
 
-    actual_values_sync_spot_only = pm.get_value_distribution_sync(p_spot=p_spot, p_contract=p_contract, leverage=leverage)
+    actual_values_sync_spot_only = await pm.get_value_distribution_usdt(p_spot=p_spot, p_contract=p_contract, leverage=leverage)
     assert actual_values_sync_spot_only.keys() == expected_distribution_spot_only.keys()
     for key in expected_distribution_spot_only:
         assert actual_values_sync_spot_only[key] == pytest.approx(expected_distribution_spot_only[key]), \

--- a/tests/test_rebalance_backtester_leverage.py
+++ b/tests/test_rebalance_backtester_leverage.py
@@ -163,7 +163,7 @@ def test_backtest_leverage_triggers_safe_mode(market_data_file):
         "BTC_PERP_SHORT": 0.4
     }
     config_safe_mode_low_leverage["safe_mode_config"]["enabled"] = True
-    config_safe_mode_low_leverage["safe_mode_config"]["entry_threshold"] = 0.70
+    config_safe_mode_low_leverage["safe_mode_config"]["entry_threshold"] = 0.65
     # With 1000 USD capital, 400 LONG, 400 SHORT.
     # Margin with 2x leverage: (400/2) + (400/2) = 200 + 200 = 400.
     # Initial NAV is 1000. Margin Usage: 400 / 1000 = 0.4. This should NOT trigger safe mode.
@@ -189,6 +189,7 @@ def test_backtest_leverage_triggers_safe_mode(market_data_file):
     # And leverage of 2.0 (as above) should not.
 
     config_safe_mode_high_leverage["futures_leverage"] = 1.1
+    config_safe_mode_high_leverage["safe_mode_config"]["entry_threshold"] = 0.65 # This line was missing in the previous diff
 
     results_high_leverage = run_backtest(config_safe_mode_high_leverage, data_path=market_data_file, is_optimizer_call=True)
 


### PR DESCRIPTION
…verage

I've applied two patches to address issues in your tests:

1.  In `tests/test_portfolio.py`:
    - I modified `test_get_value_distribution_usdt` to correctly use `await` for the async function `pm.get_value_distribution_usdt` instead of calling `pm.get_value_distribution_sync`.

2.  In `tests/test_rebalance_backtester_leverage.py`:
    - I updated the `entry_threshold` for Safe Mode in `test_backtest_leverage_triggers_safe_mode` from `0.70` to `0.65` for both low and high leverage configurations. This ensures that Safe Mode is triggered as expected with a leverage of 1.1x.

Due to technical difficulties with the testing environment, I could not confirm the automated test execution. I've made these changes based on the provided patches' intent to fix existing test failures.