### PR TITLE
feat: Integrate futures_leverage into backtesting and portfolio valua…

### DIFF
--- a/config/unified_config.example.json
+++ b/config/unified_config.example.json
@@ -60,6 +60,7 @@
     ]
   },
   "backtest_settings": {
+    "futures_leverage": 5.0,
     "main_asset_symbol": "BTC",
     "apply_signal_logic": false,
     "initial_capital": 1000.0,
@@ -68,7 +69,6 @@
     "commission_maker": 0.0002,
     "use_maker_fees_in_backtest": false,
     "slippage_percent": 0.0005,
-+    "futures_leverage": 5,
     "annualization_factor": 252.0,
     "min_rebalance_interval_minutes": 10,
     "rebalance_threshold": 0.03,

--- a/src/prosperous_bot/portfolio_manager.py
+++ b/src/prosperous_bot/portfolio_manager.py
@@ -23,7 +23,7 @@ class PortfolioManager:
             size = float(p.size)
             # notional = abs(size) × contract-price (fallback→margin)
             margin = float(getattr(p, "margin", 0.0))
-            notional = abs(margin * leverage)
+            notional = abs(size) * p_contract if p_contract is not None else abs(float(getattr(p, "margin", 0.0)) * leverage)
             if size > 0:
                 long_val += notional
             elif size < 0:

--- a/src/prosperous_bot/rebalance_backtester.py
+++ b/src/prosperous_bot/rebalance_backtester.py
@@ -157,6 +157,7 @@ def run_backtest(params_dict, data_path, is_optimizer_call=True, trial_id_for_re
     params = _subst_symbol(params, main_symbol)
 
     leverage = params.get("futures_leverage", 5.0)
+    leverage = leverage if leverage > 0 else 1e-9
     target_weights_normal = params.get('target_weights_normal', {}) 
     if not target_weights_normal:
         target_weights_normal = params.get('target_weights', {})
@@ -394,7 +395,7 @@ def run_backtest(params_dict, data_path, is_optimizer_call=True, trial_id_for_re
             # Defaulting to a very small number if leverage is 0 to avoid ZeroDivisionError,
             # effectively making margin usage extremely high if leverage is misconfigured to 0.
             # A leverage of 0 for a leveraged position doesn't make practical sense.
-            effective_leverage_for_margin = leverage if leverage > 0 else 1e-9
+            effective_leverage_for_margin = leverage
             margin_for_long = portfolio['btc_long_value_usdt'] / effective_leverage_for_margin
             margin_for_short = portfolio['btc_short_value_usdt'] / effective_leverage_for_margin
             used_margin_usdt = margin_for_long + margin_for_short

--- a/src/prosperous_bot/rebalance_engine.py
+++ b/src/prosperous_bot/rebalance_engine.py
@@ -116,9 +116,12 @@ class RebalanceEngine:
         if hasattr(self.portfolio, "get_nav_usdt"):
             nav = await self.portfolio.get_nav_usdt(p_spot=p_spot, p_contract=p_contract)
         else:  # stub-портфели в tests
-            dist_abs = await self.portfolio.get_value_distribution_usdt(p_spot=p_spot, p_contract=p_contract)
+            leverage = self.params.get("futures_leverage", 5.0)
+            effective_leverage = leverage if leverage > 0 else 1e-9
+            p_contract_adjusted = p_contract * effective_leverage if p_contract else None
+            dist_abs = await self.portfolio.get_value_distribution_usdt(p_spot=p_spot, p_contract=p_contract_adjusted)
             nav = sum(dist_abs.values())
-        dist = await self.portfolio.get_value_distribution_usdt(p_spot=p_spot, p_contract=p_contract)
+        dist = await self.portfolio.get_value_distribution_usdt(p_spot=p_spot, p_contract=p_contract_adjusted)
         thr = self._dynamic_threshold(self.base_threshold_pct, atr_24h_pct)
 
         orders = []


### PR DESCRIPTION
…tion

This commit introduces support for `futures_leverage` across the rebalancing backtester and related modules.

Key changes:
- `rebalance_backtester.py`:
    - Ensures that the `leverage` parameter obtained from configuration is sanitized (forced positive, e.g., 1e-9 if zero or negative) before being used in P&L calculations for futures positions and in margin usage computations.
- `rebalance_engine.py`:
    - The `build_orders` method now fetches `futures_leverage` from parameters.
    - It calculates an `effective_leverage` (ensuring positivity).
    - This `effective_leverage` is used to adjust `p_contract` (contract price) before passing it to the portfolio manager, creating `p_contract_adjusted`.
- `portfolio_manager.py`:
    - The `get_value_distribution_usdt` method has been updated to prioritize the (now leverage-adjusted) `p_contract` parameter for calculating the notional value of futures positions.
    - If `p_contract` is provided, it's used with the position size (`abs(size) * p_contract`).
    - If `p_contract` is not provided, it falls back to using the position's margin and the method's own `leverage` parameter (`abs(margin * leverage)`).
- `config/unified_config.example.json`:
    - Added `"futures_leverage": 5.0` to the `backtest_settings` section as an example configuration.
- `tests/test_rebalance_backtester_leverage.py`:
    - Verified that existing tests cover various leverage scenarios (0x, 1x, 1.1x, 2x, 5x, 10x), including their impact on P&L and Safe Mode activation.

These changes ensure that `futures_leverage` from the configuration is consistently applied and respected throughout the backtesting and portfolio valuation process, allowing for more accurate simulation of leveraged futures trading.