### PR TITLE
Fix: Ensure correct futures_leverage handling in NAV and rebalance

### DIFF
--- a/src/prosperous_bot/monitoring.py
+++ b/src/prosperous_bot/monitoring.py
@@ -21,7 +21,8 @@ async def startup():
 
 @app.get("/metrics")
 async def metrics(p_spot: float):
-    values = await portfolio.get_value_distribution_usdt(p_spot, p_contract=None)
+    leverage = 5.0  # Default leverage
+    values = await portfolio.get_value_distribution_usdt(p_spot, p_contract=None, leverage=leverage)
     positions = await portfolio.get_positions_with_margin()
     try:
         pos = next(p for p in positions if p.contract == "BTC_USDT" and abs(float(p.size)) >= 1)

--- a/src/prosperous_bot/portfolio_manager.py
+++ b/src/prosperous_bot/portfolio_manager.py
@@ -21,9 +21,11 @@ class PortfolioManager:
         long_val = short_val = 0.0                      # notional in USDT
         for p in positions:
             size = float(p.size)
-            # notional = abs(size) × contract-price (fallback→margin)
             margin = float(getattr(p, "margin", 0.0))
-            notional = abs(size) * p_contract if p_contract is not None else abs(float(getattr(p, "margin", 0.0)) * leverage)
+            if p_contract is not None:
+                notional = abs(size) * p_contract
+            else:
+                notional = margin * leverage  # fallback if contract price not given
             if size > 0:
                 long_val += notional
             elif size < 0:

--- a/src/prosperous_bot/rebalance_engine.py
+++ b/src/prosperous_bot/rebalance_engine.py
@@ -113,15 +113,15 @@ class RebalanceEngine:
         Формирует список словарей-ордеров:
           {symbol, side, qty, notional_usdt, asset_key}
         """
+        leverage = self.params.get("futures_leverage", 5.0)
+        effective_leverage = leverage if leverage > 0 else 1e-9
+        p_contract_adjusted = p_contract * effective_leverage if p_contract else None
         if hasattr(self.portfolio, "get_nav_usdt"):
             nav = await self.portfolio.get_nav_usdt(p_spot=p_spot, p_contract=p_contract)
         else:  # stub-портфели в tests
-            leverage = self.params.get("futures_leverage", 5.0)
-            effective_leverage = leverage if leverage > 0 else 1e-9
-            p_contract_adjusted = p_contract * effective_leverage if p_contract else None
-            dist_abs = await self.portfolio.get_value_distribution_usdt(p_spot=p_spot, p_contract=p_contract_adjusted)
+            dist_abs = await self.portfolio.get_value_distribution_usdt(p_spot=p_spot, p_contract=p_contract_adjusted, leverage=leverage)
             nav = sum(dist_abs.values())
-        dist = await self.portfolio.get_value_distribution_usdt(p_spot=p_spot, p_contract=p_contract_adjusted)
+        dist = await self.portfolio.get_value_distribution_usdt(p_spot=p_spot, p_contract=p_contract_adjusted, leverage=leverage)
         thr = self._dynamic_threshold(self.base_threshold_pct, atr_24h_pct)
 
         orders = []

--- a/tests/test_portfolio.py
+++ b/tests/test_portfolio.py
@@ -15,7 +15,8 @@ async def test_get_value_distribution_usdt(mocker):
         gate_api.Position(size="-0.02", contract="BTC_USDT", unrealised_pnl="-20", margin="200")
     ])
     pm = PortfolioManager(spot_api, fut_api)
-    values = await pm.get_value_distribution_usdt(p_spot=50000, p_contract=250)
+    leverage = 5.0  # Default leverage
+    values = await pm.get_value_distribution_usdt(p_spot=50000, p_contract=250, leverage=leverage)
     assert isinstance(values, dict)
     assert all(k in values for k in ("BTC_SPOT", "BTC_PERP_SHORT", "BTC_PERP_LONG"))
     assert all(isinstance(v, float) for v in values.values())

--- a/tests/test_portfolio_property.py
+++ b/tests/test_portfolio_property.py
@@ -24,7 +24,8 @@ def test_value_distribution_valid(spot, short, long, price):
         ]
     )
     pm = PortfolioManager(spot_api, fut_api)
-    values = asyncio.run(pm.get_value_distribution_usdt(price, 250))
+    leverage = 5.0  # Default leverage
+    values = asyncio.run(pm.get_value_distribution_usdt(price, 250, leverage=leverage))
     total = sum(values.values())
     assert all(v >= 0 for v in values.values())
     assert total > 0


### PR DESCRIPTION
This commit applies a series of changes to ensure `futures_leverage` is correctly passed and utilized in portfolio value calculations, rebalancing logic, and tests.

- Modified `rebalance_engine.py` and `monitoring.py` to correctly pass the `leverage` parameter to `get_value_distribution_usdt`.
- Updated `portfolio_manager.py` to refine the calculation of notional value in `get_value_distribution_usdt`, especially when `p_contract` is not provided, ensuring `leverage` is correctly applied.
- Added explicit `leverage` parameter to calls in `tests/test_portfolio.py` and `tests/test_portfolio_property.py` for clarity and robustness.
- Verified that `tests/test_rebalance_backtester_leverage.py` already explicitly sets `futures_leverage` in its test configurations, aligning with the original intent for test modifications.