### PR TITLE
Integrate futures_leverage into rebalance_backtester.py

### DIFF
--- a/src/prosperous_bot/rebalance_backtester.py
+++ b/src/prosperous_bot/rebalance_backtester.py
@@ -160,7 +160,16 @@ def run_backtest(params_dict, data_path, is_optimizer_call=True, trial_id_for_re
     if leverage <= 0:
         logging.warning("Invalid 'futures_leverage' <= 0 found in config. Using fallback leverage = 1e-9.")
         leverage = 1e-9
-    portfolio['effective_leverage'] = leverage
+
+    portfolio = {
+        'usdt_balance': initial_portfolio_value_usdt, 'btc_spot_qty': 0.0,
+        'btc_spot_lots': [], 'btc_long_value_usdt': 0.0, 'btc_short_value_usdt': 0.0,
+        'prev_btc_price': None, 'total_commissions_usdt': 0.0, 'total_slippage_usdt': 0.0,
+        'current_operational_mode': 'NORMAL_MODE', 'num_circuit_breaker_triggers': 0,
+        'num_safe_mode_entries': 0, 'time_steps_in_safe_mode': 0,
+        'last_rebalance_attempt_timestamp': None,
+        'effective_leverage': leverage  # ← добавлено сюда
+    }
     target_weights_normal = params.get('target_weights_normal', {}) 
     if not target_weights_normal:
         target_weights_normal = params.get('target_weights', {})
@@ -382,8 +391,9 @@ def run_backtest(params_dict, data_path, is_optimizer_call=True, trial_id_for_re
 
         if portfolio['prev_btc_price'] is not None and portfolio['prev_btc_price'] > 0:
             price_change_ratio = current_price / portfolio['prev_btc_price']
-            portfolio['btc_long_value_usdt'] += portfolio['btc_long_value_usdt'] * leverage * (price_change_ratio - 1)
-            portfolio['btc_short_value_usdt'] += portfolio['btc_short_value_usdt'] * leverage * (1 - price_change_ratio)
+            lev = portfolio.get("effective_leverage", 5.0)
+            portfolio['btc_long_value_usdt'] += portfolio['btc_long_value_usdt'] * lev * (price_change_ratio - 1)
+            portfolio['btc_short_value_usdt'] += portfolio['btc_short_value_usdt'] * lev * (1 - price_change_ratio)
         
         total_portfolio_value = calculate_portfolio_value(
             portfolio['usdt_balance'], portfolio['btc_spot_qty'],
@@ -396,8 +406,9 @@ def run_backtest(params_dict, data_path, is_optimizer_call=True, trial_id_for_re
             # Defaulting to a very small number if leverage is 0 to avoid ZeroDivisionError,
             # effectively making margin usage extremely high if leverage is misconfigured to 0.
             # A leverage of 0 for a leveraged position doesn't make practical sense.
-            margin_for_long = portfolio['btc_long_value_usdt'] / leverage
-            margin_for_short = portfolio['btc_short_value_usdt'] / leverage
+            lev = portfolio.get("effective_leverage", 5.0)
+            margin_for_long = portfolio['btc_long_value_usdt'] / lev
+            margin_for_short = portfolio['btc_short_value_usdt'] / lev
             used_margin_usdt = margin_for_long + margin_for_short
             margin_usage_ratio = used_margin_usdt / nav if nav > 0 else 0.0
         else:


### PR DESCRIPTION
This commit applies three patches to correctly integrate `futures_leverage` into the `rebalance_backtester.py` script.

Key changes include:
- Storing `effective_leverage` directly within the `portfolio` dictionary.
- Utilizing `effective_leverage` from the `portfolio` for calculating profit and loss on long and short positions.
- Using `effective_leverage` from the `portfolio` for margin calculations.

These changes ensure that `futures_leverage` correctly influences:
- The step-by-step valuation of `btc_long_value_usdt` and `btc_short_value_usdt`.
- The calculation of `margin_usage_ratio`.
- The `used_leverage` value reported in the output.

This also allows the unit test `test_rebalance_backtester_leverage.py` to correctly track the impact of leverage on P&L.