### PR TITLE
feat: Implement simulate_rebalance and integrate into backtester

### DIFF
--- a/tests/test_simulate_rebalance_pnl.py
+++ b/tests/test_simulate_rebalance_pnl.py
@@ -1,0 +1,23 @@
+import pandas as pd
+from prosperous_bot.rebalance_backtester import simulate_rebalance
+
+def test_simulate_rebalance_pnl():
+    # фиктивные свечи
+    data = pd.DataFrame([
+        {"close": 100},
+        {"close": 110},  # close long
+        {"close": 90},   # close short
+    ])
+
+    orders_by_step = {
+        0: [{"asset_key": "BTC_PERP_LONG", "side": "buy", "qty": 1}],
+        1: [{"asset_key": "BTC_PERP_LONG", "side": "sell", "qty": 1}],
+        2: [{"asset_key": "BTC_PERP_SHORT", "side": "buy", "qty": 2}],
+        2: [{"asset_key": "BTC_PERP_SHORT", "side": "sell", "qty": 2}]
+    }
+
+    trades = simulate_rebalance(data, orders_by_step, leverage=5.0)
+    assert len(trades) >= 1
+    for trade in trades:
+        assert "pnl_gross_quote" in trade
+        assert trade["pnl_gross_quote"] != 0


### PR DESCRIPTION
This commit introduces the `simulate_rebalance` function and integrates it into the `run_backtest` process.

Key changes:
1.  I added the `simulate_rebalance(data, orders_by_step, leverage)` function to `src/prosperous_bot/rebalance_backtester.py`. This function simulates trades based on a pre-defined set of orders for each time step and calculates PnL, including leverage effects.

2.  I modified `run_backtest` in `src/prosperous_bot/rebalance_backtester.py`:
    *   It now collects trade intentions (asset, side, quantity in base asset terms) generated by its internal rebalancing logic into an `orders_by_step` dictionary, keyed by the DataFrame index of the market data.
    *   After processing all historical data, it calls `simulate_rebalance` with the market data and the collected `orders_by_step`.
    *   The detailed PnL trade log from `simulate_rebalance` is saved to `rebalance_trades.csv` within the backtest's report directory.

3.  I added a new unit test file `tests/test_simulate_rebalance_pnl.py`. This file contains `test_simulate_rebalance_pnl` to verify the basic PnL calculation of the `simulate_rebalance` function using sample data.

Note: I couldn't definitively confirm if the tests passed due to some persistent internal errors I encountered. However, I made the code changes according to your specification and structured them to be testable.