### PR TITLE
Add integration test for neutral rebalance PnL

### DIFF
--- a/tests/test_neutral_rebalance.py
+++ b/tests/test_neutral_rebalance.py
@@ -1,0 +1,64 @@
+"""
+Integration test: BTC-neutral rebalance must yield zero PnL under ideal conditions.
+"""
+
+import pathlib
+import pytest
+
+# Import run_backtest with robust fallback
+try:
+    from prosperous_bot.rebalance_backtester import run_backtest
+except ImportError:
+    from rebalance_backtester import run_backtest  # type: ignore
+
+DATA_FILE = pathlib.Path("graphs/BTCUSDT_data.csv") # Adjusted path
+
+
+@pytest.mark.integration
+def test_btc_neutral_rebalance_zero_pnl(tmp_path):
+    if not DATA_FILE.exists():
+        pytest.skip(f"Historical data file not found: {DATA_FILE}")
+
+    init_nav = 10_000.0  # USDT
+
+    params = {
+        "main_asset_symbol": "BTC",
+        "futures_leverage": 5.0,
+        "apply_signal_logic": False,
+        "min_rebalance_interval_minutes": 0,
+        "rebalance_threshold": 0.0,
+        # No frictions
+        "taker_commission_rate": 0.0,
+        "maker_commission_rate": 0.0,
+        "slippage_percent": 0.0,
+        # Capital & reports
+        "initial_portfolio_value_usdt": init_nav,
+        "report_path_prefix": str(tmp_path),
+        # Target weights for perfect neutrality (x5 leverage)
+        "target_weights_normal": {
+            "BTC_SPOT": 0.35,
+            "BTC_PERP_LONG": 0.36,
+            "BTC_PERP_SHORT": 0.29,
+        },
+        # Switch off extra logic
+        "safe_mode_config": {"enabled": False},
+        "circuit_breaker_config": {"enabled": False},
+        "data_settings": {
+            "csv_file_path": str(DATA_FILE),
+            "signals_csv_path": "",
+            "timestamp_col": "timestamp",
+            "ohlc_cols": {
+                "open": "open",
+                "high": "high",
+                "low": "low",
+                "close": "close",
+            },
+            "price_col_for_rebalance": "close",
+        },
+    }
+
+    results = run_backtest(params, str(DATA_FILE), is_optimizer_call=True)
+
+    assert results["status"] == "Completed"
+    assert results["total_net_pnl_usdt"] == pytest.approx(0.0, abs=1e-6)
+    assert results["final_portfolio_value_usdt"] == pytest.approx(init_nav, abs=1e-6)


### PR DESCRIPTION
This commit introduces a new integration test in `tests/test_neutral_rebalance.py`.

The test (`test_btc_neutral_rebalance_zero_pnl`) runs the backtester on the full `BTCUSDT_data.csv` dataset under ideal conditions:
- No commissions or slippage
- `apply_signal_logic` is False
- Specific neutral target weights:
  - BTC_SPOT: 0.35
  - BTC_PERP_LONG: 0.36
  - BTC_PERP_SHORT: 0.29

The test asserts that under these conditions, the `total_net_pnl_usdt` is approximately zero and the `final_portfolio_value_usdt` remains approximately equal to the initial NAV.

The test is marked with `@pytest.mark.integration` and will be picked up by the existing CI pipeline configuration. A failure in this test will result in a CI pipeline failure.

This test is added to help verify the correctness of the position holding logic in `simulate_rebalance()`, as per the issue description.