### PR TITLE
Fix: Correct rebalance weights, enable reports, and update PnL proces…

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,5 @@
 addopts = -q
 pythonpath = .
 asyncio_default_fixture_loop_scope = function
+markers =
+    integration: долгий тест на полном историческом наборе данных

--- a/src/prosperous_bot/rebalance_backtester.py
+++ b/src/prosperous_bot/rebalance_backtester.py
@@ -18,7 +18,8 @@ def simulate_rebalance(data, orders_by_step, leverage=5.0):
 
         for order in step_orders:
             key = order['asset_key']
-            side = order['side']
+            # допускаем 'BUY' / 'SELL' в верхнем регистре
+            side = order['side'].lower()
             qty = order['qty']
 
             if side == 'buy':

--- a/tests/test_neutral_rebalance.py
+++ b/tests/test_neutral_rebalance.py
@@ -35,10 +35,11 @@ def test_btc_neutral_rebalance_zero_pnl(tmp_path):
         "initial_portfolio_value_usdt": init_nav,
         "report_path_prefix": str(tmp_path),
         # Target weights for perfect neutrality (x5 leverage)
+        # 0.35 + 5 × (0.29 − 0.36) = 0  → рыночно-нейтрально
         "target_weights_normal": {
             "BTC_SPOT": 0.35,
-            "BTC_PERP_LONG": 0.36,
-            "BTC_PERP_SHORT": 0.29,
+            "BTC_PERP_LONG": 0.29,
+            "BTC_PERP_SHORT": 0.36,
         },
         # Switch off extra logic
         "safe_mode_config": {"enabled": False},
@@ -56,8 +57,9 @@ def test_btc_neutral_rebalance_zero_pnl(tmp_path):
             "price_col_for_rebalance": "close",
         },
     }
-
-    results = run_backtest(params, str(DATA_FILE), is_optimizer_call=True)
+    # Генерируем полный отчёт; не режим оптимизатора
+    params["generate_reports"] = True
+    results = run_backtest(params, str(DATA_FILE), is_optimizer_call=False)
 
     assert results["status"] == "Completed"
     assert results["total_net_pnl_usdt"] == pytest.approx(0.0, abs=1e-6)


### PR DESCRIPTION
…sing

This commit addresses the following:
- Adjusted target weights in `test_neutral_rebalance.py` to 0.35 (SPOT), 0.29 (LONG), and 0.36 (SHORT) for delta neutrality.
- Enabled report generation in `test_neutral_rebalance.py` by setting `generate_reports` to True and `is_optimizer_call` to False.
- Modified `simulate_rebalance` in `rebalance_backtester.py` to convert order side to lowercase, ensuring correct PnL calculation.
- Registered the `integration` marker in `pytest.ini`.

Note: Due to an issue with the execution environment, I could not run the tests to verify these changes. The modifications were applied based on the provided patches in the issue description.