### PR TITLE
I've added a `min_order_notional_usdt` parameter to help avoid micro-…

### DIFF
--- a/config/unified_config.example.json
+++ b/config/unified_config.example.json
@@ -60,6 +60,8 @@
     ]
   },
   "backtest_settings": {
+    // минимальный объём ордера (SPOT и PERP) в USDT; ордера меньше не создаются
+    "min_order_notional_usdt": 10.0,
     "futures_leverage": 5.0,
     "main_asset_symbol": "BTC",
     "apply_signal_logic": false,

--- a/src/prosperous_bot/rebalance_backtester.py
+++ b/src/prosperous_bot/rebalance_backtester.py
@@ -639,7 +639,9 @@ def run_backtest(params_dict, data_path, is_optimizer_call=True, trial_id_for_re
 
             for asset_key_trade, usdt_value_to_trade in adjustments.items():
                 if asset_key_trade == "USDT": continue
-                if abs(usdt_value_to_trade) < 1.0: continue
+                # игнорируем ребаланс-движения меньше порога
+                if abs(usdt_value_to_trade) < params.get("min_order_notional_usdt", 10.0):
+                    continue
                 # Patch for dust minimization: Start
                 if current_price > 0:
                     asset_qty_unrounded = abs(usdt_value_to_trade) / current_price

--- a/src/prosperous_bot/rebalance_engine.py
+++ b/src/prosperous_bot/rebalance_engine.py
@@ -150,7 +150,9 @@ class RebalanceEngine:
 
             side = "buy" if qty_float > 0 else "sell"
             qty_lot = self._round_lot(abs(qty_float))
-            if abs(delta_usdt) < 1.0: # Проверяем абсолютное значение delta_usdt
+            # пропускаем ордера меньше заданного порога
+            min_ord = self.params.get("min_order_notional_usdt", 10.0)
+            if abs(delta_usdt) < min_ord:
                 continue
 
             orders.append(

--- a/tests/test_neutral_rebalance.py
+++ b/tests/test_neutral_rebalance.py
@@ -33,6 +33,7 @@ def test_btc_neutral_rebalance_zero_pnl(tmp_path):
         "slippage_percent": 0.0,
         # Capital & reports
         "initial_portfolio_value_usdt": init_nav,
+        "min_order_notional_usdt": 10.0,
         "report_path_prefix": str(tmp_path),
         # Target weights for perfect neutrality (x5 leverage)
         # 0.35 + 5 × (0.29 − 0.36) = 0  → рыночно-нейтрально


### PR DESCRIPTION
…trades.

This introduces a new configuration parameter, `min_order_notional_usdt` (defaulting to 10 USDT), to prevent the creation of orders with a notional value below this threshold.

This change affects:
- `config/unified_config.example.json`: I added the new parameter to backtest_settings.
- `src/prosperous_bot/rebalance_engine.py`: I updated this to filter orders based on `min_order_notional_usdt`.
- `src/prosperous_bot/rebalance_backtester.py`: I updated this to filter simulated orders based on `min_order_notional_usdt`.
- `tests/test_neutral_rebalance.py`: I included the new parameter in the test setup.

This should resolve issues where the rebalance optimizer might get stuck on processing very small (micro) trades.