### PR TITLE
Add symbol conversion utilities and update usage

### DIFF
--- a/src/prosperous_bot/rebalance_engine.py
+++ b/src/prosperous_bot/rebalance_engine.py
@@ -2,7 +2,7 @@ import asyncio
 import copy
 from .logging_config import configure_root # This will be adjusted by hand later if patch fails
 configure_root()
-from .utils import get_lot_step
+from .utils import get_lot_step, to_gate_pair
 import logging
 from datetime import datetime, timedelta
 from typing import Optional
@@ -76,11 +76,21 @@ class RebalanceEngine:
                 logging.warning("RebalanceEngine: 'target_weights_normal' (or 'target_weights') not found in params or direct args. Using empty target_weights.")
                 self.target_weights = {}
 
+        # --- Всегда храним тикеры в Gate-формате «BASE_USDT» ---
+        self.spot_asset_symbol = to_gate_pair(
+            self.params.get(
+                "spot_asset_symbol",
+                spot_asset_symbol if spot_asset_symbol else f"{sym}_USDT",
+            )
+        )
 
-        # Spot and futures symbols from params, with fallbacks if needed
-        self.spot_asset_symbol = self.params.get('spot_asset_symbol', spot_asset_symbol if spot_asset_symbol else "BTCUSDT") # Example default
-        self.futures_contract_symbol_base = self.params.get('futures_contract_symbol_base',
-            futures_contract_symbol_base if futures_contract_symbol_base else "BTCUSDT_PERP") # Example default
+        # для фьючерсов Gate использует тот же вид «BTC_USDT»
+        self.futures_contract_symbol_base = to_gate_pair(
+            self.params.get(
+                "futures_contract_symbol_base",
+                futures_contract_symbol_base if futures_contract_symbol_base else f"{sym}_USDT",
+            )
+        )
 
         # Threshold from params or direct argument
         # Direct threshold_pct (legacy) or base_threshold_pct argument takes precedence

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,32 @@
+import pytest
+from src.prosperous_bot.utils import to_gate_pair, to_binance_symbol
+
+# Tests for to_gate_pair
+@pytest.mark.parametrize("test_input, expected_output", [
+    ("BTCUSDT", "BTC_USDT"),      # Binance style
+    ("ETH_USDT", "ETH_USDT"),    # Gate.io style
+    ("solusdt", "SOL_USDT"),      # Lowercase
+    ("BnbUsdt", "BNB_USDT"),      # Mixed case
+    ("ADABTC", "ADABTC"),        # Non-USDT pair
+    ("", ""),                    # Empty string
+    (None, None),                # None input
+    ("SUSHI_USDT", "SUSHI_USDT"), # Already Gate style with underscore in name
+    ("PEPEUSDT", "PEPE_USDT"),     # Binance style
+])
+def test_to_gate_pair(test_input, expected_output):
+    assert to_gate_pair(test_input) == expected_output
+
+# Tests for to_binance_symbol
+@pytest.mark.parametrize("test_input, expected_output", [
+    ("BTC_USDT", "BTCUSDT"),      # Gate.io style
+    ("ETHUSDT", "ETHUSDT"),      # Binance style
+    ("sol_usdt", "SOLUSDT"),      # Lowercase
+    ("Bnb_Usdt", "BNBUSDT"),      # Mixed case
+    ("ADA_BTC", "ADA_BTC"),      # Non-USDT pair (current behavior)
+    ("PEPE_USDT", "PEPEUSDT"),   # Gate.io style
+    ("", ""),                    # Empty string
+    (None, None),                # None input
+    ("SUSHI_USDT", "SUSHIUSDT"), # Gate style with underscore in name (becomes SUSHIUSDT)
+])
+def test_to_binance_symbol(test_input, expected_output):
+    assert to_binance_symbol(test_input) == expected_output


### PR DESCRIPTION
This commit introduces two new helper functions in `utils.py`:
- `to_gate_pair(symbol)`: Converts a trading symbol to Gate.io format (e.g., "BTC_USDT").
- `to_binance_symbol(pair)`: Converts a Gate.io pair to Binance format (e.g., "BTCUSDT").

These functions handle various input cases, including already formatted symbols, different capitalizations, and None inputs.

The `rebalance_engine.py` has been updated to use `to_gate_pair` to standardize `spot_asset_symbol` and `futures_contract_symbol_base` to the Gate.io format internally.

The `get_lot_step` function in `utils.py` has also been refactored to use `to_gate_pair`, making the symbol formatting more robust when querying the Gate.io API.

Unit tests for these new utility functions have been added to `tests/test_utils.py`.