### PR TITLE
Refactor quantity rounding and enhance backtester flexibility

### DIFF
--- a/src/prosperous_bot/utils.py
+++ b/src/prosperous_bot/utils.py
@@ -56,20 +56,6 @@ def to_binance_symbol(pair: str) -> str:
         return p.replace("_USDT", "USDT")
     return p
 
-# -----------------------------------------------------------------
-#  Helpers for tests (>= 1 qty rule)
-# -----------------------------------------------------------------
-def _qty_for_tests(asset_key: str, delta_usdt: float, p_spot: float) -> float:
-    """
-    Юнит-тесты ожидают qty >= 1 или BTC_USDT.
-    Возвращаем:
-      для _SPOT - округлённый notional в USDT (>= 1)
-      для perp - округление к ближайшему контракту (>= 1)
-    """
-    if asset_key.endswith("_SPOT"):
-        return max(int(round(abs(delta_usdt))), 1)  # USDT-notional
-    return max(int(round(abs(delta_usdt))), 1)      # контракты
-
 @lru_cache(maxsize=32)
 def get_lot_step(symbol: str) -> float:
     """


### PR DESCRIPTION
This commit introduces several changes:

1.  Removes the `_qty_for_tests` utility function. The quantity calculation logic for trades is now handled more robustly within the `RebalanceEngine`.

2.  Updates `RebalanceEngine`'s `build_orders` method:
    -   Uses `self._round_lot` for quantity rounding.
    -   Determines `lot_step` dynamically: uses `get_lot_step()` for
        SPOT assets and a fixed `lot_step` of 1.0 for PERP contracts.
    -   Removes the direct dependency on `_qty_for_tests`.

3.  Enhances `RebalanceBacktester`'s `simulate_rebalance` function:
    -   Adds a `force_close_open_positions` parameter (defaulting to `False`)
        to control whether remaining open positions are closed at the end
        of the simulation.
    -   The calling context (e.g., `run_backtest`) now passes this flag,
        setting it to `not is_optimizer_call`. This allows differentiation
        in behavior between regular backtests and optimization runs.