### PR TITLE
Refactor: Apply diff for utils, rebalance engine, backtester, and tests

### DIFF
--- a/src/prosperous_bot/rebalance_engine.py
+++ b/src/prosperous_bot/rebalance_engine.py
@@ -2,7 +2,7 @@ import asyncio
 import copy
 from .logging_config import configure_root # This will be adjusted by hand later if patch fails
 configure_root()
-from .utils import get_lot_step, to_gate_pair, _qty_for_tests
+from prosperous_bot.utils import get_lot_step, to_gate_pair, _qty_for_tests
 import logging
 from datetime import datetime, timedelta
 from typing import Optional
@@ -78,8 +78,12 @@ class RebalanceEngine:
 
         # --- Всегда храним тикеры в Gate-формате «BASE_USDT» ---
         # spot_asset_symbol always in Gate.io format, e.g. "BTC_USDT"
-        spot_asset_symbol_param = self.params.get("spot_asset_symbol", spot_asset_symbol if spot_asset_symbol else f"{sym}_USDT")
-        self.spot_asset_symbol = to_gate_pair(spot_asset_symbol_param)
+        self.spot_asset_symbol = to_gate_pair(
+            self.params.get(
+                "spot_asset_symbol",
+                spot_asset_symbol if spot_asset_symbol else "BTC_USDT",
+            )
+        )
 
         # для фьючерсов Gate использует тот же вид «BTC_USDT»
         self.futures_contract_symbol_base = to_gate_pair(

--- a/tests/test_neutral_rebalance.py
+++ b/tests/test_neutral_rebalance.py
@@ -33,8 +33,9 @@ def test_btc_neutral_rebalance_zero_pnl(tmp_path):
         "slippage_percent": 0.0,
         # Capital & reports
         "initial_portfolio_value_usdt": init_nav,
-        "min_order_notional_usdt": 10.0,
-        "min_rebalance_interval_minutes": 30,
+        # тест обнуляет фильтры, но код дубляжно снимает их сам
+        "min_order_notional_usdt": 0.0,
+        "min_rebalance_interval_minutes": 0,
         "report_path_prefix": str(tmp_path),
         # Target weights for perfect neutrality (x5 leverage)
         # 0.35 + 5 × (0.29 − 0.36) = 0  → рыночно-нейтрально


### PR DESCRIPTION
This commit incorporates a series of changes from a provided diff:

- Updated `utils.py` with a new `to_gate_pair` function and modifications to `_qty_for_tests`.
- Modified `rebalance_engine.py` to use the new `to_gate_pair` function for symbol formatting and updated import paths. Adjusted quantity calculation logic for test scenarios.
- Enhanced `rebalance_backtester.py` by refining parameter adjustments for ideal backtesting conditions (when `apply_signal_logic` is false) and introduced a numerical noise cleanup for P&L metrics.
- Adjusted `tests/test_neutral_rebalance.py` to set `min_order_notional_usdt` to 0.0 and `min_rebalance_interval_minutes` to 0, aligning with the backtester changes for neutral runs.