### PR TITLE
Refactor: Update optimizer objective and NAV std calculation

### DIFF
--- a/src/prosperous_bot/rebalance_backtester.py
+++ b/src/prosperous_bot/rebalance_backtester.py
@@ -878,6 +878,19 @@ def run_backtest(params_dict, data_path, is_optimizer_call=True, trial_id_for_re
     metrics["total_net_pnl_percent"] = (metrics["total_net_pnl_usdt"] / initial_portfolio_value_usdt) * 100 if initial_portfolio_value_usdt != 0 else 0
     metrics["total_trades"] = len(df_trades)
 
+    # Calculate NAV standard deviation percentage
+    if not df_equity.empty:
+        nav_series = df_equity['portfolio_value_usdt']
+        if initial_portfolio_value_usdt != 0:
+            metrics["nav_std_percent"] = nav_series.std() / initial_portfolio_value_usdt * 100
+        else:
+            # Handle case where initial_portfolio_value_usdt is zero to avoid division by zero
+            metrics["nav_std_percent"] = 0.0
+            logging.warning("initial_portfolio_value_usdt is 0. 'nav_std_percent' calculated as 0.0. This might affect optimization if NAV std is expected.")
+    else:
+        # Handle case where df_equity is empty (e.g., no trades or data)
+        metrics["nav_std_percent"] = 0.0
+
     # ─── Numerical-noise cleanup (≤ 1 cent) ───────────────────────
     tol = float(params.get("neutrality_pnl_tolerance_usd", 1e-2))
     if abs(metrics["total_net_pnl_usdt"]) <= tol:


### PR DESCRIPTION
Modifies the rebalance optimizer's objective function to minimize a composite metric based on PnL, NAV standard deviation, and commissions.
- Adds `math.isfinite` check to Optuna trial pruning for robustness.
- Updates target weight setting in the optimizer to use direct assignment.

Adjusts the rebalance backtester to calculate `nav_std_percent` as the standard deviation of absolute NAV values, normalized by initial capital, to support the new optimization objective.