### PR TITLE
Fix: Make base_config_factory return a callable factory

### DIFF
--- a/tests/test_rebalance_backtester_leverage.py
+++ b/tests/test_rebalance_backtester_leverage.py
@@ -59,8 +59,14 @@ def market_data_file():
 # --- New Fixtures for annualization tests ---
 @pytest.fixture
 def base_config_factory():
-    """Returns a deep copy of BASE_CONFIG for modification in tests."""
-    return copy.deepcopy(BASE_CONFIG)
+    """
+    Returns a **factory function**; в тестах вызываем:
+
+        config = base_config_factory()  # -> fresh deepcopy(dict)
+    """
+    def _factory():
+        return copy.deepcopy(BASE_CONFIG)
+    return _factory
 
 @pytest.fixture
 def market_data_file_factory():


### PR DESCRIPTION
The `base_config_factory` fixture in `tests/test_rebalance_backtester_leverage.py` was previously returning a dictionary directly. However, tests were invoking it as a function (e.g., `config = base_config_factory()`), which caused a `TypeError: 'dict' object is not callable`.

This change modifies the fixture to return a nested factory function. This inner function, when called, performs the `copy.deepcopy(BASE_CONFIG)` operation. This makes the fixture behave as a callable that produces a fresh configuration dictionary upon each call, aligning with its intended use in the tests and resolving the TypeError.