### PR TITLE
chore: init — cross-platform env scripts + CI-first policy

### DIFF
--- a/docs/HOW_TO_WORK.md
+++ b/docs/HOW_TO_WORK.md
@@ -1,3 +1,37 @@
+## Initial setup (CI-first, cross-platform)
+
+**Цель:** среда разворачивается одинаково на Windows/macOS/Linux и не требует `source .venv/bin/activate`. Скрипты для людей:
+
+- POSIX: `scripts/init_env.sh`
+- Windows: `scripts/init_env.ps1`
+
+Оба скрипта используют `python -m …` с интерпретатором из `.venv`, а не активацию шелла. Это совпадает с тем, как запускается CI.
+
+### Политика тестов
+- **Источник истины — GitHub Actions.** Jules **не** запускает локальные тесты; он только применяет diff и открывает Draft PR (probe для `feature/ci-*` / strict для остальных).
+- **Probe (быстрый дым):** ветки `feature/ci-*` → `-m "not integration"`, без порога покрытия.
+- **Strict (боевой):** все прочие ветки → весь набор тестов + `--cov-fail-under=90`.
+
+### Быстрые команды для разработчика (локально)
+```bash
+# POSIX
+./scripts/init_env.sh
+.venv/bin/python -m pytest -q -m "not integration" --maxfail=1
+```
+```powershell
+# Windows
+pwsh -File .\scripts\init_env.ps1
+.\.venv\Scripts\python -m pytest -q -m "not integration" --maxfail=1
+```
+
+### Триггер CI без коммита в код
+- **Actions → Python CI → Run workflow** (если включён `workflow_dispatch`), либо
+- «пинг-коммит» в `tests/**` (с path-фильтрами это гарантированно запускает пайплайн).
+
+### Замечания
+- Никаких «зашитых» путей вида `C:\…` в тестах; для путей используем утилиты `pathlib`.
+- Все параметры — только через `unified_config*.json`; тесты не меняют логику и не вшивают значения.
+
 # How-to work (короткая памятка)
 **SoT:** весь код/конфиги/отчёты — только в GitHub (`FMProducer/prosperous_bot`). В «Файлах проекта» держим только метадокументы.
 

--- a/scripts/init_env.ps1
+++ b/scripts/init_env.ps1
@@ -1,0 +1,26 @@
+Param()
+$ErrorActionPreference = "Stop"
+Write-Host "[init] Windows bootstrap starting…" -ForegroundColor Cyan
+
+# 1) Create virtualenv (idempotent)
+python -m venv .venv
+
+# 2) Use venv's interpreter directly (без активации)
+$VENV_PY = Join-Path $PWD ".venv\Scripts\python.exe"
+
+# 3) Tools and deps
+& $VENV_PY -m pip install --upgrade pip setuptools wheel
+if (Test-Path "requirements.txt") {
+  & $VENV_PY -m pip install -r requirements.txt
+}
+& $VENV_PY -m pip install pytest pytest-cov pytest-asyncio pandas ruff
+
+# 4) Diagnostics
+& $VENV_PY -V
+& $VENV_PY -m pip -V
+
+Write-Host ""
+Write-Host "✅ Windows env ready." -ForegroundColor Green
+Write-Host "To activate (optional): .\.venv\Scripts\Activate.ps1"
+Write-Host "Unit-only local test: .\.venv\Scripts\python -m pytest -q -m 'not integration' --maxfail=1"
+Write-Host ""

--- a/scripts/init_env.sh
+++ b/scripts/init_env.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+echo "[init] POSIX bootstrap starting…"
+
+# 1) Create virtualenv (idempotent)
+python3 -m venv .venv
+
+# 2) Use venv's interpreter directly (без 'source')
+VENV_PY="$(pwd)/.venv/bin/python"
+
+# 3) Tools and deps
+"$VENV_PY" -m pip install --upgrade pip setuptools wheel
+if [[ -f requirements.txt ]]; then
+  "$VENV_PY" -m pip install -r requirements.txt
+fi
+"$VENV_PY" -m pip install pytest pytest-cov pytest-asyncio pandas ruff
+
+# 4) Diagnostics
+"$VENV_PY" -V
+"$VENV_PY" -m pip -V
+
+echo
+echo "✅ POSIX env ready."
+echo "To activate manually: 'source .venv/bin/activate' (optional)"
+echo "To run tests locally (unit-only): '.venv/bin/python -m pytest -q -m \"not integration\" --maxfail=1'"
+echo


### PR DESCRIPTION
- Adds `scripts/init_env.sh` for POSIX (macOS/Linux) and `scripts/init_env.ps1` for Windows to create a consistent, activation-free Python virtual environment.
- These scripts mirror the CI setup by using the venv's python interpreter directly.
- Updates `docs/HOW_TO_WORK.md` to document the new scripts and a "CI-first" policy, where GitHub Actions is the source of truth for test outcomes.
- The documentation includes quick-start commands for local development.

## Цель и влияние на KPI
Опишите, что меняется и зачем. Укажите ожидаемое влияние: Sharpe, Profit Factor, Max DD.

## Изменения
- [ ] Список изменённых модулей и сценариев
- [ ] Миграции/фиче-флаги/совместимость

## Проверки
- [ ] Юнит-тесты добавлены/обновлены; **coverage ≥ 90%**
- [ ] Смоук-бэктест выполнен, отчёты в `reports/`
- [ ] Конфиги согласованы с `unified_config*.json`
- [ ] Нет секретов/персональных данных в коде/логах
- [ ] Документация/roadmap обновлены при изменении логики

## Риски и откат
Граничные кейсы, план отката (revert / feature-flag / Safe-Mode).

## Локальные команды воспроизведения
```bash
pytest -q --maxfail=1 --disable-warnings --cov=. --cov-report=term-missing
```
```
