### PR TITLE
Fix(ci): enable manual workflow dispatch and set coverage to 90%

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,13 @@
 name: Python CI
 
 on:
-  # ручной запуск из UI/CLI
+  # Ручной запуск из UI/CLI (явный input помогает избежать глюков UI и упрощает аудит)
   workflow_dispatch:
+    inputs:
+      reason:
+        description: "Why run CI manually?"
+        required: false
+        default: "manual run"
   push:
     paths:
       - 'src/**'
@@ -73,10 +78,10 @@ jobs:
           pytest -q -m "not integration" --disable-warnings --maxfail=1 --cov=src/prosperous_bot --cov-report=xml
 
       # STRICT: все ветки вне feature/ci-* — полный набор тестов и порог покрытия ≥ 90%
-      - name: "Run tests (strict: coverage >= 85)"
+      - name: "Run tests (strict: coverage >= 90)"
         if: ${{ !(startsWith(github.ref, 'refs/heads/feature/ci-') || startsWith(github.head_ref || '', 'feature/ci-')) }}
         run: |
-          pytest -q --disable-warnings --maxfail=1 --cov=src/prosperous_bot --cov-report=xml --cov-fail-under=85
+          pytest -q --disable-warnings --maxfail=1 --cov=src/prosperous_bot --cov-report=xml --cov-fail-under=90
 
       - name: Upload coverage artifact
         if: ${{ always() && hashFiles('coverage.xml') != '' }}


### PR DESCRIPTION
This commit fixes the manual CI trigger and stabilizes the workflow.

- The `workflow_dispatch` event is now configured with an explicit `reason` input. This makes the "Run workflow" button appear correctly in the GitHub Actions UI and improves auditability of manual runs.
- The code coverage threshold for the 'strict' test job has been increased from 85% to 90%, aligning it with the project's quality policy.

These changes ensure that the CI can be triggered manually from the `prosperous_bot` branch and that the quality gates are correctly enforced.

## Цель и влияние на KPI
Опишите, что меняется и зачем. Укажите ожидаемое влияние: Sharpe, Profit Factor, Max DD.

## Изменения
- [ ] Список изменённых модулей и сценариев
- [ ] Миграции/фиче-флаги/совместимость

## Проверки
- [ ] Юнит-тесты добавлены/обновлены; **coverage ≥ 90%**
- [ ] Смоук-бэктест выполнен, отчёты в `reports/`
- [ ] Конфиги согласованы с `unified_config*.json`
- [ ] Нет секретов/персональных данных в коде/логах
- [ ] Документация/roadmap обновлены при изменении логики

## Риски и откат
Граничные кейсы, план отката (revert / feature-flag / Safe-Mode).

## Локальные команды воспроизведения
```bash
pytest -q --maxfail=1 --disable-warnings --cov=. --cov-report=term-missing
```
```
