### PR TITLE
Feat: Enable fixed report paths for testing and update example config

### DIFF
--- a/config/unified_config.example.json
+++ b/config/unified_config.example.json
@@ -60,6 +60,7 @@
     ]
   },
   "backtest_settings": {
+    "use_fixed_report_path": true,
     "futures_leverage": 5.0,
     "main_asset_symbol": "BTC",
     "apply_signal_logic": false,
@@ -73,7 +74,7 @@
     "min_rebalance_interval_minutes": 10,
     "rebalance_threshold": 0.03,
     "target_weights_normal": {
-      "{main_asset_symbol}_SPOT": 0.80,
+      "{main_asset_symbol}_SPOT": 0.8,
       "{main_asset_symbol}_PERP_LONG": 0.02,
       "{main_asset_symbol}_PERP_SHORT": 0.18
     },
@@ -86,10 +87,10 @@
     "safe_mode_config": {
       "enabled": true,
       "metric_to_monitor": "margin_usage",
-      "entry_threshold": 0.70,
-      "exit_threshold": 0.60,
+      "entry_threshold": 0.7,
+      "exit_threshold": 0.6,
       "target_weights_safe": {
-        "{main_asset_symbol}_SPOT": 0.80,
+        "{main_asset_symbol}_SPOT": 0.8,
         "{main_asset_symbol}_PERP_LONG": 0.02,
         "{main_asset_symbol}_PERP_SHORT": 0.18,
         "USDT": 0.0


### PR DESCRIPTION
This commit introduces two key changes to facilitate reliable testing of report generation:

1.  **Backtester Code (`src/prosperous_bot/rebalance_backtester.py`):**
    - Modified `run_backtest` to accept a `use_fixed_report_path` boolean parameter within its `params` dictionary.
    - If `use_fixed_report_path` is `true`, reports are saved directly into the directory specified by `report_path_prefix` (defaulting to `reports/`), without any timestamped subdirectories.
    - If `false` (default), the existing behavior of creating timestamped output directories is maintained.
    - Report saving logic was also standardized: if `generate_reports` is true, all reports are saved to the determined path (fixed or timestamped); if false, no reports are saved. This addresses inconsistencies where `equity.csv` might not have been saved when `rebalance_trades.csv` was.

2.  **Example Configuration (`config/unified_config.example.json`):**
    - Added `"use_fixed_report_path": true` to the `backtest_settings`.
    - Ensured `"report_path_prefix": "./reports/"` is present.
    - This change configures the default example backtest run to output reports directly into the `reports/` folder.

These changes collectively should allow tests that expect report files (e.g., `equity.csv`, `rebalance_trades.csv`) in a fixed `reports/` location to pass when the backtester is run using this updated example configuration or a similar test-specific setup.

## Цель и влияние на KPI
Опишите, что меняется и зачем. Укажите ожидаемое влияние: Sharpe, Profit Factor, Max DD.

## Изменения
- [ ] Список изменённых модулей и сценариев
- [ ] Миграции/фиче-флаги/совместимость

## Проверки
- [ ] Юнит-тесты добавлены/обновлены; **coverage ≥ 90%**
- [ ] Смоук-бэктест выполнен, отчёты в `reports/`
- [ ] Конфиги согласованы с `unified_config*.json`
- [ ] Нет секретов/персональных данных в коде/логах
- [ ] Документация/roadmap обновлены при изменении логики

## Риски и откат
Граничные кейсы, план отката (revert / feature-flag / Safe-Mode).

## Локальные команды воспроизведения
```bash
pytest -q --maxfail=1 --disable-warnings --cov=. --cov-report=term-missing
```
```
