### PR TITLE
feat: Add epsilon property to D3QN_PER_Agent

### DIFF
--- a/third_party/rl-trading-binance/agent.py
+++ b/third_party/rl-trading-binance/agent.py
@@ -227,6 +227,15 @@ class D3QN_PER_Agent:
 
         logger.info("D3QN_PER_Agent initialized.")
 
+    @property
+    def epsilon(self) -> float:
+        """Calculates the current exploration rate (epsilon) based on the decay schedule."""
+        if self.eps_frames <= 0:
+            return self.eps_end
+        return self.eps_end + (self.eps_start - self.eps_end) * np.exp(
+            -1.0 * self.total_steps / self.eps_frames
+        )
+
     def load_onnx_session(self, onnx_path: str):
         """Loads ONNX runtime session for inference."""
         if ort is None:


### PR DESCRIPTION
Adds a read-only `epsilon` property to the `D3QN_PER_Agent` class.

This property calculates the current epsilon value based on the agent's total steps and the configured decay parameters, making it accessible to the training loop for logging and resolving the `AttributeError`.

## Цель и влияние на KPI
Опишите, что меняется и зачем. Укажите ожидаемое влияние: Sharpe, Profit Factor, Max DD.

## Изменения
- [ ] Список изменённых модулей и сценариев
- [ ] Миграции/фиче-флаги/совместимость

## Проверки
- [ ] Юнит-тесты добавлены/обновлены; **coverage ≥ 90%**
- [ ] Смоук-бэктест выполнен, отчёты в `reports/`
- [ ] Конфиги согласованы с `unified_config*.json`
- [ ] Нет секретов/персональных данных в коде/логах
- [ ] Документация/roadmap обновлены при изменении логики

## Риски и откат
Граничные кейсы, план отката (revert / feature-flag / Safe-Mode).

## Локальные команды воспроизведения
```bash
pytest -q --maxfail=1 --disable-warnings --cov=. --cov-report=term-missing
```
```
