### PR TITLE
Enforce state flattening and validation in D3QN_PER_Agent

### DIFF
--- a/third_party/rl-trading-binance/agent.py
+++ b/third_party/rl-trading-binance/agent.py
@@ -75,6 +75,9 @@ class D3QN_PER_Agent:
         mc_use_for_target=False, mc_n_target_samples=1, mc_target_agg="mean_max",
         mc_uncertainty_guided_explore=False, mc_uncertainty_beta=0.0
     ) -> None:
+        # Persist state shape for consistency checks with the model
+        self.state_shape = state_shape
+
         # Приводим к torch.device на случай, если из конфига придёт строка "cuda"/"cpu"
         self.device = torch.device(device)
         self.action_dim = action_dim
@@ -189,6 +192,59 @@ class D3QN_PER_Agent:
 
         logger.info("D3QN_PER_Agent initialized.")
 
+    # ------------------------------------------------------------------
+    # Internal helpers for state flattening
+    # ------------------------------------------------------------------
+    def _flatten_single_state(self, state: np.ndarray) -> np.ndarray:
+        """
+        Ensure that a single state is a flat 1D float32 vector.
+        This matches the expectation of DuelingQNetwork.forward(),
+        which takes a 2D tensor [batch, history_flat_size + additional_feats].
+        """
+        arr = np.asarray(state, dtype=np.float32)
+        if arr.ndim == 1:
+            return arr
+        return arr.reshape(-1)
+
+    def _flatten_batch_states(self, states: np.ndarray) -> np.ndarray:
+        """
+        Ensure that a batch of states is a 2D float32 array [N, F].
+        """
+        arr = np.asarray(states, dtype=np.float32)
+        if arr.ndim == 2:
+            return arr
+        # First dimension is assumed to be batch, flatten the rest
+        new_shape = (arr.shape[0], int(np.prod(arr.shape[1:], dtype=np.int64)))
+        return arr.reshape(new_shape)
+
+    def _check_flat_state_size(self, flat_state: np.ndarray) -> None:
+        """
+        Validate that flat_state length matches model's expected input size.
+        """
+        channels, history_len, _ = self.policy_net.input_shape
+        history_flat_size = channels * history_len
+        additional_feats = getattr(self.policy_net, "additional_feats", 0)
+        expected_size = history_flat_size + additional_feats
+        actual_size = int(flat_state.size)
+        if actual_size != expected_size:
+            logger.error(
+                "State size mismatch for policy_net input: expected %d "
+                "(history: %d, additional: %d), got %d",
+                expected_size, history_flat_size, additional_feats, actual_size,
+            )
+            raise AssertionError(
+                f"Flat state size {actual_size} does not match expected {expected_size}"
+            )
+
+        # Optional: lightweight debug statistics about the input range
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(
+                "Flat state stats: min=%.6f max=%.6f std=%.6f",
+                float(flat_state.min(initial=0.0)),
+                float(flat_state.max(initial=0.0)),
+                float(flat_state.std() if flat_state.size > 1 else 0.0),
+            )
+
     def export_to_onnx(self, file_path: str):
         """Exports the policy network to the ONNX format.
 
@@ -302,10 +358,15 @@ class D3QN_PER_Agent:
         # Базовая ε-жадная логика (epsilon берется из self.eps_* расписания внутри агента)
         # Если mc_enable=False или training=False — используем обычный путь как прежде.
         if not (training and self.mc_enable and self.mc_n_action_samples > 1):
-            return self._select_action_base(state, training, return_qvals, use_cache, cache_key)
+            # Always flatten and validate the state before passing to the base path
+            flat_state = self._flatten_single_state(state)
+            self._check_flat_state_size(flat_state)
+            return self._select_action_base(flat_state, training, return_qvals, use_cache, cache_key)
 
         # MC-dropout: ансамбль из N проходов онлайн-сети.
-        state_tensor = torch.from_numpy(state).float().unsqueeze(0).to(self.device)
+        flat_state = self._flatten_single_state(state)
+        self._check_flat_state_size(flat_state)
+        state_tensor = torch.from_numpy(flat_state).float().unsqueeze(0).to(self.device)
         q_samples = self._q_forward_samples(self.policy_net, state_tensor, self.mc_n_action_samples)  # [N,1,A]
         q_mean = q_samples.mean(dim=0).squeeze(0)    # [A]
         q_std  = q_samples.std(dim=0, unbiased=False).squeeze(0)  # [A]
@@ -365,7 +426,9 @@ class D3QN_PER_Agent:
 
         # --- ONNX INFERENCE PATH ---
         if self.ort_session is not None and not training:
-            ort_inputs = {self.ort_session.get_inputs()[0].name: state.astype(np.float32)[np.newaxis, ...]}
+            flat_state = self._flatten_single_state(state)
+            self._check_flat_state_size(flat_state)
+            ort_inputs = {self.ort_session.get_inputs()[0].name: flat_state[np.newaxis, ...]}
             qvals = self.ort_session.run(None, ort_inputs)[0][0] # [1, A] -> [A]
             return qvals if return_qvals else int(np.argmax(qvals))
         # ---------------------------
@@ -375,14 +438,18 @@ class D3QN_PER_Agent:
                 qvals = self.qval_cache[cache_key]
             else:
                 with torch.no_grad():
-                    tensor = torch.from_numpy(state).float().unsqueeze(0).to(self.device)
+                    flat_state = self._flatten_single_state(state)
+                    self._check_flat_state_size(flat_state)
+                    tensor = torch.from_numpy(flat_state).float().unsqueeze(0).to(self.device)
                     qvals = self.policy_net(tensor).cpu().numpy().squeeze(0)
                 self.qval_cache[cache_key] = qvals
             qvals = qvals.squeeze(0)
             return qvals if return_qvals else int(np.argmax(qvals))
 
         with torch.no_grad():
-            tensor = torch.from_numpy(state).float().unsqueeze(0).to(self.device)
+            flat_state = self._flatten_single_state(state)
+            self._check_flat_state_size(flat_state)
+            tensor = torch.from_numpy(flat_state).float().unsqueeze(0).to(self.device)
             qvals = self.policy_net(tensor).cpu().numpy().squeeze(0)
             return qvals if return_qvals else int(np.argmax(qvals))
 
@@ -402,13 +469,20 @@ class D3QN_PER_Agent:
         Returns:
             list[int]: A list of selected actions for each state in the batch.
         """
+        # Ensure states have shape [N, F] matching the model's expected input size
+        flat_states = self._flatten_batch_states(states)
+        if flat_states.shape[0] == 0:
+            return []
+        # Validate size on the first sample (all others share the same feature dimension)
+        self._check_flat_state_size(flat_states[0])
+
         self.policy_net.eval()  # детерминированный инференс вне MC-дропаут
-        n = int(states.shape[0])
+        n = int(flat_states.shape[0])
         with torch.no_grad(), torch.autocast(
             device_type=("cuda" if self.device.type == "cuda" else "cpu"),
             enabled=getattr(self, "use_amp", False)
         ):
-            x = torch.as_tensor(states, dtype=torch.float32, device=self.device)
+            x = torch.as_tensor(flat_states, dtype=torch.float32, device=self.device)
             q = self.policy_net(x)              # [N, action_dim]
             greedy = q.argmax(dim=1).detach().to("cpu").numpy()  # [N]
         # epsilon-greedy по батчу

--- a/third_party/rl-trading-binance/validate_model_ohlcv_z.py
+++ b/third_party/rl-trading-binance/validate_model_ohlcv_z.py
@@ -138,12 +138,8 @@ def evaluate_agent(
                 logging.warning(f"Could not parse ticker/date from key: {keys[i]}")
         
         while not done:
-            # FIX: Transpose obs (L, C) -> (C, L, 1) for Agent
-            obs_agent = obs
-            if obs_agent.ndim == 2 and obs_agent.shape[1] == agent.state_shape[0]:
-                obs_agent = np.expand_dims(obs_agent.T, -1)
-
-            action = agent.select_action(obs_agent, training=False)
+            # Agent is now responsible for flattening and validating the state
+            action = agent.select_action(obs, training=False)
             obs, reward, done, _, info = env.backtest_step(
                 action=action,
                 signal_dt=signal_dt_for_step,

--- a/verify_agent_changes.py
+++ b/verify_agent_changes.py
@@ -1,0 +1,88 @@
+import sys
+import os
+import numpy as np
+import torch
+import logging
+
+# Add the directory to sys.path
+sys.path.append('third_party/rl-trading-binance')
+
+from agent import D3QN_PER_Agent
+
+# Mock DuelingQNetwork to avoid complex initialization
+class MockPolicyNet:
+    def __init__(self, input_shape, additional_feats):
+        self.input_shape = input_shape
+        self.additional_feats = additional_feats
+
+    def eval(self):
+        pass
+
+def test_agent_flattening():
+    logging.basicConfig(level=logging.DEBUG)
+
+    state_shape = (3, 10, 1)
+    action_dim = 3
+    additional_feats = 5
+
+    # Initialize agent
+    # We need to mock policy_net before it's used in _check_flat_state_size
+    agent = D3QN_PER_Agent(
+        state_shape=state_shape,
+        action_dim=action_dim,
+        cnn_maps=[16],
+        cnn_kernels=[3],
+        cnn_strides=[1],
+        dense_val=[32],
+        dense_adv=[32],
+        additional_feats=additional_feats,
+        dropout_model=0.1,
+        device="cpu",
+        gamma=0.99,
+        learning_rate=1e-4,
+        batch_size=32,
+        buffer_size=1000,
+        target_update_freq=100,
+        train_start=100,
+        per_alpha=0.6,
+        per_beta_start=0.4,
+        per_beta_frames=1000,
+        eps_start=1.0,
+        eps_end=0.1,
+        eps_frames=1000,
+        epsilon=0.1,
+        max_gradient_norm=1.0
+    )
+
+    # Test _flatten_single_state
+    state_2d = np.random.rand(30 + additional_feats)
+    flat = agent._flatten_single_state(state_2d)
+    assert flat.shape == (35,)
+    assert flat.dtype == np.float32
+
+    state_3d = np.random.rand(3, 10, 1)
+    # The agent expects a flat vector that includes additional_feats.
+    # If state_3d doesn't include them, it will fail _check_flat_state_size later.
+    # But _flatten_single_state just flattens.
+    flat = agent._flatten_single_state(state_3d)
+    assert flat.shape == (30,)
+
+    # Test _check_flat_state_size
+    # Expected size = 3 * 10 + 5 = 35
+    agent._check_flat_state_size(np.random.rand(35))
+
+    try:
+        agent._check_flat_state_size(np.random.rand(30))
+        assert False, "Should have raised AssertionError"
+    except AssertionError as e:
+        print(f"Caught expected error: {e}")
+
+    # Test _flatten_batch_states
+    states_batch = np.random.rand(10, 3, 10, 1)
+    flat_batch = agent._flatten_batch_states(states_batch)
+    assert flat_batch.shape == (10, 30)
+
+    print("Agent flattening tests passed!")
+
+if __name__ == "__main__":
+    test_agent_flattening()


### PR DESCRIPTION
This change addresses the "constant Advantage" issue observed after migrating to per-ticker Rolling Z-normalization. It ensures that the input fed to the DuelingQNetwork is consistently flattened and validated against the expected size (history size + additional features). By moving this responsibility to the agent, we make it robust against different observation formats from the environment or validation scripts, and provide clear error messages (AssertionError) in case of shape mismatches. Lightweight DEBUG logging is also added to help monitor input statistics.

---
*PR created automatically by Jules for task [2336412398106025201](https://jules.google.com/task/2336412398106025201) started by @FMProducer*