### PR TITLE
Optimize training pipeline for static Z-Score normalization

### DIFF
--- a/third_party/rl-trading-binance/tests/test_static_norm.py
+++ b/third_party/rl-trading-binance/tests/test_static_norm.py
@@ -1,0 +1,70 @@
+
+import sys
+import os
+import numpy as np
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from trading_environment_z import TradingEnvironment
+
+def test_static_normalization():
+    # Setup data
+    raw_seq = np.array([
+        [100, 105, 95, 102, 1000],
+        [102, 107, 101, 104, 1100],
+        [104, 109, 103, 106, 1200],
+    ], dtype=np.float32)
+
+    norm_stats = {
+        'TEST': {
+            'mean': [102.0, 107.0, 99.0, 104.0, 1100.0],
+            'std': [2.0, 2.0, 2.0, 2.0, 100.0]
+        }
+    }
+
+    env_kwargs = {
+        "sequences": [raw_seq],
+        "keys": ['TEST_ASSET'],
+        "render_mode": None,
+        "full_seq_len": 3,
+        "num_features": 5,
+        "num_actions": 3,
+        "flat_state_size": 15,
+        "initial_balance": 10000.0,
+        "pre_signal_len": 1,
+        "datachannels": ["open", "high", "low", "close", "volume"],
+        "slippage": 0.0,
+        "transaction_fee": 0.0,
+        "agent_session_len": 2,
+        "agent_history_len": 1,
+        "input_history_len": 1,
+        "pricechannels": ["open", "high", "low", "close"],
+        "volumechannels": ["volume"],
+        "otherchannels": [],
+        "action_history_len": 0,
+        "inaction_penalty_ratio": 0.0,
+        "norm_stats": norm_stats
+    }
+
+    env = TradingEnvironment(**env_kwargs)
+    env.reset()
+
+    # current_asset_name is TEST
+    # current_step is 0
+    # _get_observation should return the first row normalized by norm_stats['TEST']
+    obs = env._get_observation()
+
+    # If using MLP mode, obs is a flat vector where the first num_features elements are the normalized data
+    expected_norm = (raw_seq[0] - np.array(norm_stats['TEST']['mean'])) / np.array(norm_stats['TEST']['std'])
+
+    # raw_seq[0] = [100, 105, 95, 102, 1000]
+    # mean = [102, 107, 99, 104, 1100]
+    # std = [2, 2, 2, 2, 100]
+    # expected = [-1, -1, -2, -1, -1]
+
+    np.testing.assert_allclose(obs[:5], expected_norm, atol=1e-5)
+    print("Static normalization test passed!")
+
+if __name__ == "__main__":
+    test_static_normalization()

--- a/third_party/rl-trading-binance/trading_environment_z.py
+++ b/third_party/rl-trading-binance/trading_environment_z.py
@@ -107,6 +107,7 @@ class TradingEnvironment(gym.Env):
         filter_direction: Optional[str] = None,
         allowed_directions: Optional[List[str]] = None,
         mirror_mode: bool = True,  # Добавлено для управления инверсией
+        norm_stats: Optional[Dict] = None,
         **kwargs,
     ) -> None:
         if not sequences:
@@ -256,6 +257,7 @@ class TradingEnvironment(gym.Env):
         self.allow_opposite_trades = allow_opposite_trades
         self.max_trades_per_episode = max_trades_per_episode
         self.allowed_directions = allowed_directions
+        self.norm_stats = norm_stats
 
         # Определяем индекс действия "закрыть"
         self.close_action = close_action_index
@@ -885,22 +887,29 @@ class TradingEnvironment(gym.Env):
             padding = np.zeros((pad_len, self.num_features), dtype=np.float32)
             raw_window = np.concatenate((padding, raw_window), axis=0)
 
-        # --- ROLLING Z-SCORE NORMALIZATION ---
+        # --- NORMALIZATION ---
         normalized = raw_window.astype(np.float32).copy()
         
-        # 1. Normalize Prices (Grouped: Open, High, Low, Close share stats)
-        if self.price_indices:
-            p_data = raw_window[:, self.price_indices]
-            p_mean = np.mean(p_data)
-            p_std = np.std(p_data) + 1e-8
-            normalized[:, self.price_indices] = (p_data - p_mean) / p_std
-            
-        # 2. Normalize Volume (Individually per channel)
-        if self.volume_indices:
-            v_data = raw_window[:, self.volume_indices]
-            v_mean = np.mean(v_data, axis=0)
-            v_std = np.std(v_data, axis=0) + 1e-8
-            normalized[:, self.volume_indices] = (v_data - v_mean) / v_std
+        if self.norm_stats and self.current_asset_name in self.norm_stats:
+            stats = self.norm_stats[self.current_asset_name]
+            means = np.array(stats['mean'], dtype=np.float32)
+            stds = np.array(stats['std'], dtype=np.float32)
+            normalized = (normalized - means) / stds
+        else:
+            # Fallback to ROLLING Z-SCORE NORMALIZATION
+            # 1. Normalize Prices (Grouped: Open, High, Low, Close share stats)
+            if self.price_indices:
+                p_data = raw_window[:, self.price_indices]
+                p_mean = np.mean(p_data)
+                p_std = np.std(p_data) + 1e-8
+                normalized[:, self.price_indices] = (p_data - p_mean) / p_std
+
+            # 2. Normalize Volume (Individually per channel)
+            if self.volume_indices:
+                v_data = raw_window[:, self.volume_indices]
+                v_mean = np.mean(v_data, axis=0)
+                v_std = np.std(v_data, axis=0) + 1e-8
+                normalized[:, self.volume_indices] = (v_data - v_mean) / v_std
 
         unrealized = 0.0
         if self.position != 0:

--- a/third_party/rl-trading-binance/train_ohlcv_z.py
+++ b/third_party/rl-trading-binance/train_ohlcv_z.py
@@ -650,7 +650,8 @@ def run_training_session(
     plots_dir: str,
     session_name: str,
     cfg_mod: Optional[Any] = None,
-    py_config_path: Optional[str] = None
+    py_config_path: Optional[str] = None,
+    norm_stats: Optional[Dict] = None
 ) -> Dict[str, Any]:
     """
     Runs a complete training and validation session for a given dataset.
@@ -808,6 +809,7 @@ def run_training_session(
         "filter_direction": getattr(cfg.market, "filter_direction", None),
         "allowed_directions": getattr(cfg.market, "allowed_directions", None),
         "mirror_mode": getattr(cfg.market, "mirror_mode", False), # Передаем из конфига
+        "norm_stats": norm_stats,
     }
     num_envs = getattr(cfg.vec, "num_envs", 1)
     # Important Warning:
@@ -1141,7 +1143,8 @@ def main(cfg: MasterConfig = None, cfg_mod: Optional[Any] = None):
                 models_dir=fold_models_dir,
                 plots_dir=fold_plots_dir,
                 session_name=f"{session_name}_fold_{i+1}",
-                cfg_mod=cfg_mod
+                cfg_mod=cfg_mod,
+                norm_stats={} # Fallback to rolling for WFV for now or we could compute stats here
             )
             wfv_results.append(best_metrics)
 
@@ -1158,8 +1161,14 @@ def main(cfg: MasterConfig = None, cfg_mod: Optional[Any] = None):
         allowed_assets = getattr(cfg.paper, "symbols", None)
         if allowed_assets == "ALL": allowed_assets = None
 
-        train_seqs, train_keys = load_and_prep_data(cfg.paths.train_data_path, "Train", {}, cfg, allowed_assets)
-        val_seqs, val_keys = load_and_prep_data(cfg.paths.val_data_path, "Validation", {}, cfg, allowed_assets)
+        # --- ГЕНЕРАЦИЯ NORM_STATS.JSON ---
+        logging.info("📊 Calculating static normalization stats...")
+        stats_path = os.path.join(models_dir, "norm_stats.json")
+        norm_stats = compute_norm_stats(cfg.paths.train_data_path, cfg, norm_stats_path=stats_path)
+        logging.info(f"✅ Norm stats saved to {stats_path}")
+
+        train_seqs, train_keys = load_and_prep_data(cfg.paths.train_data_path, "Train", norm_stats, cfg, allowed_assets)
+        val_seqs, val_keys = load_and_prep_data(cfg.paths.val_data_path, "Validation", norm_stats, cfg, allowed_assets)
 
         if not train_seqs:
             logging.error("Training data not loaded. Exiting.")
@@ -1193,7 +1202,8 @@ def main(cfg: MasterConfig = None, cfg_mod: Optional[Any] = None):
             plots_dir=plots_dir,
             session_name=session_name,
             cfg_mod=cfg_mod,
-            py_config_path=py_config_path # Pass the path
+            py_config_path=py_config_path, # Pass the path
+            norm_stats=norm_stats
         )
 
         bundle_cfg = getattr(cfg_mod, "bundle_cfg", getattr(cfg, "bundle", object()))

--- a/third_party/rl-trading-binance/validate_model_ohlcv_z.py
+++ b/third_party/rl-trading-binance/validate_model_ohlcv_z.py
@@ -422,7 +422,7 @@ def validate(config_path, checkpoint_path, out_dir, episode_num, args):
     env_kwargs = {
         "sequences": val_seqs,
         "keys": val_keys,
-        "stats": norm_stats,
+        "norm_stats": norm_stats,
         "full_seq_len": cfg.seq.full_seq_len,
         "num_features": val_seqs[0].shape[1],
         "num_actions": cfg.market.num_actions,


### PR DESCRIPTION
This PR optimizes the RL training pipeline by replacing dynamic rolling Z-Score normalization with static normalization based on pre-calculated dataset statistics. This improves both training performance (vectorized O(1) complexity per step) and consistency between training and validation.

Key changes:
1.  **trading_environment_z.py**: `TradingEnvironment` now accepts a `norm_stats` dictionary. If provided, `_get_observation` uses these stats for static normalization. Vectorized NumPy operations are used for efficiency.
2.  **train_ohlcv_z.py**: The `main` function now calls `compute_norm_stats` to generate global statistics from the training dataset before the training starts. These stats are saved to `norm_stats.json` in the session's model directory.
3.  **validate_model_ohlcv_z.py**: Updated to ensure it loads `norm_stats.json` from the checkpoint directory and passes it correctly to the environment.
4.  **Tests**: Added `third_party/rl-trading-binance/tests/test_static_norm.py` to verify the new normalization path. Existing tests also passed.

---
*PR created automatically by Jules for task [13070964881061758475](https://jules.google.com/task/13070964881061758475) started by @FMProducer*