### PR TITLE
Fix Constant Advantage issue in D3QN pipeline

### DIFF
--- a/third_party/rl-trading-binance/agent.py
+++ b/third_party/rl-trading-binance/agent.py
@@ -721,7 +721,8 @@ class D3QN_PER_Agent:
 
                 self.scaler.scale(weighted_loss).backward()
                 self.scaler.unscale_(self.optimizer)
-                torch.nn.utils.clip_grad_norm_(self.policy_net.parameters(), self.max_gradient_norm)
+                # Предотвращаем взрыв градиентов, который убивает веса
+                torch.nn.utils.clip_grad_norm_(self.policy_net.parameters(), max_norm=0.5)
                 self.scaler.step(self.optimizer)
                 self.scaler.update()
         else:
@@ -766,7 +767,8 @@ class D3QN_PER_Agent:
                 weighted_loss = weighted_td_loss
             
             weighted_loss.backward()
-            torch.nn.utils.clip_grad_norm_(self.policy_net.parameters(), self.max_gradient_norm)
+            # Предотвращаем взрыв градиентов, который убивает веса
+            torch.nn.utils.clip_grad_norm_(self.policy_net.parameters(), max_norm=0.5)
             self.optimizer.step()
 
         td_errors = (target_q_values - current_q_values).abs().detach().cpu().numpy()

--- a/third_party/rl-trading-binance/model.py
+++ b/third_party/rl-trading-binance/model.py
@@ -83,10 +83,20 @@ class DuelingQNetwork(nn.Module):
         adv_layers.append(nn.Linear(prev, action_dim))
         self.advantage_stream = nn.Sequential(*adv_layers)
 
+        self._init_weights()
+
         # Добавляем модули для квантования
         self.quant = torch.ao.quantization.QuantStub()
         self.dequant = torch.ao.quantization.DeQuantStub()
         logger.info(f"Initialized DuelingQNetwork with QAT support...")
+
+    def _init_weights(self):
+        for m in self.modules():
+            if isinstance(m, (nn.Linear, nn.Conv1d)):
+                # Kaiming He для слоев с ReLU
+                nn.init.kaiming_normal_(m.weight, mode='fan_out', nonlinearity='relu')
+                if m.bias is not None:
+                    nn.init.constant_(m.bias, 0)
 
     def forward(self, state: Tensor, return_components: bool = False) -> Union[Tensor, Tuple[Tensor, Tensor, Tensor]]:
         # Оборачиваем вычисления для QAT

--- a/third_party/rl-trading-binance/trading_environment_z.py
+++ b/third_party/rl-trading-binance/trading_environment_z.py
@@ -894,7 +894,7 @@ class TradingEnvironment(gym.Env):
             stats = self.norm_stats[self.current_asset_name]
             means = np.array(stats['mean'], dtype=np.float32)
             stds = np.array(stats['std'], dtype=np.float32)
-            normalized = (normalized - means) / stds
+            normalized = (normalized - means) / (stds + 1e-8)
         else:
             # Fallback to ROLLING Z-SCORE NORMALIZATION
             # 1. Normalize Prices (Grouped: Open, High, Low, Close share stats)
@@ -910,6 +910,9 @@ class TradingEnvironment(gym.Env):
                 v_mean = np.mean(v_data, axis=0)
                 v_std = np.std(v_data, axis=0) + 1e-8
                 normalized[:, self.volume_indices] = (v_data - v_mean) / v_std
+
+        # Критически важно: ограничиваем выбросы, чтобы не "ослепить" нейронку
+        normalized = np.clip(normalized, -5.0, 5.0)
 
         unrealized = 0.0
         if self.position != 0:

--- a/third_party/rl-trading-binance/user_data/strategies/CustomD3QNStrategy4z.py
+++ b/third_party/rl-trading-binance/user_data/strategies/CustomD3QNStrategy4z.py
@@ -321,9 +321,11 @@ class CustomD3QNStrategy4z(IStrategy):
             pair_stats = {}
             for col in cols_to_norm:
                 if col in df_calc.columns:
+                    # Data Health Check: if std is too small, force it to 1.0 to avoid extreme scaling
+                    col_std = float(df_calc[col].std())
                     pair_stats[col] = {
                         'mean': float(df_calc[col].mean()),
-                        'std': float(df_calc[col].std()) if df_calc[col].std() != 0 else 1.0
+                        'std': col_std if col_std >= 1e-6 else 1.0
                     }
             new_stats[pair] = pair_stats
 
@@ -420,6 +422,13 @@ class CustomD3QNStrategy4z(IStrategy):
             return df
             
         df_norm = df.copy()
+
+        # Occasionally log raw stats for verification (approx once per 1000 calls)
+        if np.random.random() < 0.001:
+            for col in ['close', 'volume']:
+                if col in df.columns:
+                    logger.info(f"📊 [Data Health Check] {pair} {col} raw: mean={df[col].mean():.6f}, std={df[col].std():.6f}")
+
         for col, s in stats.items():
             if col in df_norm.columns:
                 # Z-score: (x - mean) / std


### PR DESCRIPTION
This submission fixes the "Constant Advantage" issue by implementing several stability measures in the D3QN pipeline. 

Changes:
- **trading_environment_z.py**: Added `np.clip(normalized, -5.0, 5.0)` to `_get_observation` to prevent outliers from saturating network weights. Also ensured `1e-8` epsilon is used in normalization.
- **agent.py**: Integrated `torch.nn.utils.clip_grad_norm_` with `max_norm=0.5` before the optimizer step in the `learn` method (both for AMP and FP32 branches).
- **model.py**: Added `_init_weights` method to `DuelingQNetwork` using Kaiming He initialization for Linear and Conv1d layers, called during `__init__`.
- **CustomD3QNStrategy4z.py**: 
    - Updated `update_norm_stats` to force `std = 1.0` if `std < 1e-6`.
    - Added occasional logging (0.1% probability) of raw 'close' and 'volume' mean/std in `_apply_norm` for data health monitoring.

Verification:
- Ran existing `test_trading_environment_z.py` and `test_static_norm.py` tests.
- Verified observation clipping and weight initialization with targeted scripts.
- Verified strategy importability.

---
*PR created automatically by Jules for task [8044061067179134525](https://jules.google.com/task/8044061067179134525) started by @FMProducer*