### PR TITLE
Update normalization stats calculation with log-transformed volume

### DIFF
--- a/regenerate_stats.py
+++ b/regenerate_stats.py
@@ -58,7 +58,7 @@ def calculate_normalization_stats(
                     transformed_vals = np.log(np.maximum(changes, 1e-9))
             elif ch in volume_channels:
                 # Log transform for volume channels
-                transformed_vals = np.log(channel_data + 1.0)
+                transformed_vals = np.log1p(channel_data)
             elif ch in other_channels:
                 transformed_vals = channel_data
             else:

--- a/third_party/rl-trading-binance/trading_environment_z.py
+++ b/third_party/rl-trading-binance/trading_environment_z.py
@@ -108,6 +108,7 @@ class TradingEnvironment(gym.Env):
         allowed_directions: Optional[List[str]] = None,
         mirror_mode: bool = True,  # Добавлено для управления инверсией
         norm_stats: Optional[Dict] = None,
+        use_rolling_norm: bool = True, # Добавлено для управления скользящей нормализацией
         **kwargs,
     ) -> None:
         if not sequences:
@@ -258,6 +259,7 @@ class TradingEnvironment(gym.Env):
         self.max_trades_per_episode = max_trades_per_episode
         self.allowed_directions = allowed_directions
         self.norm_stats = norm_stats
+        self.use_rolling_norm = use_rolling_norm
 
         # Определяем индекс действия "закрыть"
         self.close_action = close_action_index
@@ -868,8 +870,8 @@ class TradingEnvironment(gym.Env):
         return base_reward + shaped_reward - inaction_penalty
 
     def _get_observation(self) -> np.ndarray:
-        # The window from current_seq is already pre-normalized.
-        # load_and_prep_data has already performed Z-normalization.
+        # The window from current_seq is already pre-normalized if norm_stats is None and use_rolling_norm is False.
+        # Otherwise, load_and_prep_data returns raw data.
 
         # --- FIX: Prevent out-of-bounds access ---
         # On the final step, self.step_idx may be equal to self.agent_session_len,
@@ -890,11 +892,11 @@ class TradingEnvironment(gym.Env):
         # --- NORMALIZATION ---
         normalized = raw_window.astype(np.float32).copy()
 
-        # Канал 4 (Volume) требует сжатия логарифмом перед нормализацией
-        if normalized.shape[1] > 4:
-            normalized[:, 4] = np.log1p(normalized[:, 4])
-
         if self.norm_stats and self.current_asset_name in self.norm_stats:
+            # Канал 4 (Volume) требует сжатия логарифмом перед нормализацией
+            if normalized.shape[1] > 4:
+                normalized[:, 4] = np.log1p(normalized[:, 4])
+
             stats = self.norm_stats[self.current_asset_name]
             means = np.array(stats['mean'], dtype=np.float32)
             stds = np.array(stats['std'], dtype=np.float32)
@@ -904,7 +906,11 @@ class TradingEnvironment(gym.Env):
             normalized = (normalized - means) / (stds + 1e-8)
             # Обработка NaN в результате нормализации
             normalized = np.nan_to_num(normalized)
-        else:
+        elif self.use_rolling_norm:
+            # Канал 4 (Volume) требует сжатия логарифмом перед нормализацией
+            if normalized.shape[1] > 4:
+                normalized[:, 4] = np.log1p(normalized[:, 4])
+
             # Fallback to ROLLING Z-SCORE NORMALIZATION
             # 1. Normalize Prices (Grouped: Open, High, Low, Close share stats)
             if self.price_indices:
@@ -915,7 +921,8 @@ class TradingEnvironment(gym.Env):
 
             # 2. Normalize Volume (Individually per channel)
             if self.volume_indices:
-                v_data = raw_window[:, self.volume_indices]
+                # Используем уже трансформированные данные из normalized (там уже применен log1p для Volume)
+                v_data = normalized[:, self.volume_indices]
                 v_mean = np.mean(v_data, axis=0)
                 v_std = np.std(v_data, axis=0) + 1e-8
                 normalized[:, self.volume_indices] = (v_data - v_mean) / v_std

--- a/third_party/rl-trading-binance/train_ohlcv_z.py
+++ b/third_party/rl-trading-binance/train_ohlcv_z.py
@@ -133,6 +133,10 @@ def compute_norm_stats(npz_path: str, cfg: MasterConfig, norm_stats_path: Option
                     asset_data = asset_data[:, :, :target_channels]
 
             if asset_data.ndim == 3 and asset_data.shape[0] > 0: # (N, L, C)
+                # Индекс 4 — это Volume. Применяем log1p перед расчетом статистики.
+                if asset_data.shape[2] > 4:
+                    asset_data[:, :, 4] = np.log1p(asset_data[:, :, 4])
+
                 means = np.mean(asset_data, axis=(0, 1))
                 stds = np.std(asset_data, axis=(0, 1)) + 1e-8
                 all_stats[asset] = {'mean': means.tolist(), 'std': stds.tolist()}

--- a/third_party/rl-trading-binance/utils.py
+++ b/third_party/rl-trading-binance/utils.py
@@ -180,7 +180,7 @@ def calculate_normalization_stats(
                 changes = arr[1:] / (arr[:-1] + 1e-9)
                 vals = np.log(np.maximum(changes, 1e-9))
             elif ch in volumechannels:
-                vals = np.log(arr + 1.0)
+                vals = np.log1p(arr)
             elif ch in otherchannels:
                 vals = arr
             else:
@@ -231,7 +231,7 @@ def apply_normalization(
             padded_normed = np.concatenate((np.array([0.0], dtype=np.float32), normed_logs.astype(np.float32)))
             normed = padded_normed[-input_history_len:]
         elif ch in volumechannels:
-            logv = np.log(arr + 1.0)
+            logv = np.log1p(arr)
             normed = (logv - mean) / std
             normed = normed[-input_history_len:]
         elif ch in otherchannels:
@@ -582,11 +582,16 @@ def load_and_prep_data_from_source(sequences, keys, split_name, norm_stats):
         means = np.array(asset_stats['mean'])
         stds = np.array(asset_stats['std'])
 
-        seq_float = seq.astype(np.float32)
+        seq_float = seq.astype(np.float32).copy()
         if seq_float.shape[1] != len(means):
             continue
 
-        seq_norm = (seq_float - means) / stds
+        # Индекс 4 — это Volume. Применяем log1p перед нормализацией.
+        if seq_float.shape[1] > 4:
+            seq_float[:, 4] = np.log1p(seq_float[:, 4])
+
+        seq_norm = (seq_float - means) / (stds + 1e-8)
+        seq_norm = np.clip(seq_norm, -5.0, 5.0)
         seq_norm = seq_norm.T
         seq_norm = np.expand_dims(seq_norm, -1)
         prepped_sequences.append(seq_norm)

--- a/third_party/rl-trading-binance/validate_model_ohlcv_z.py
+++ b/third_party/rl-trading-binance/validate_model_ohlcv_z.py
@@ -69,12 +69,16 @@ def load_and_prep_data(npz_path: str, split_name: str, norm_stats: dict, cfg: Ma
             logger.error(f"Ошибка размерности для ключа {key}: ожидалось {len(means)} каналов, получено {seq.shape[1]}")
             continue
 
-        # Z-norm по каждому каналу - DISABLED for Rolling Z-Score
-        # seq = (seq - means) / (stds + 1e-8)
-        # Reshape для CNN: (L, C) -> (C, L, 1)
-        # DISABLED: TradingEnvironment enforces (L, C) input. We transpose in the loop.
-        # seq = seq.T
-        # seq = np.expand_dims(seq, -1)
+        # Важно: применяем ту же трансформацию, что и при расчете stats
+        if means is not None:
+            seq_proc = seq.astype(np.float32)
+            # Индекс 4 — это Volume.
+            if seq_proc.shape[1] > 4:
+                seq_proc[:, 4] = np.log1p(seq_proc[:, 4])
+
+            seq = (seq_proc - means) / (stds + 1e-8)
+            seq = np.clip(seq, -5.0, 5.0)
+
         sequences.append(seq)
         valid_keys.append(key)
     
@@ -422,7 +426,8 @@ def validate(config_path, checkpoint_path, out_dir, episode_num, args):
     env_kwargs = {
         "sequences": val_seqs,
         "keys": val_keys,
-        "norm_stats": norm_stats,
+        "norm_stats": None, # Данные уже нормализованы в load_and_prep_data
+        "use_rolling_norm": False,
         "full_seq_len": cfg.seq.full_seq_len,
         "num_features": val_seqs[0].shape[1],
         "num_actions": cfg.market.num_actions,

--- a/verify_norm_changes.py
+++ b/verify_norm_changes.py
@@ -1,0 +1,170 @@
+
+import numpy as np
+import sys
+import os
+
+# Add project root to path
+sys.path.append(os.path.join(os.getcwd(), "third_party/rl-trading-binance"))
+
+from trading_environment_z import TradingEnvironment
+
+def test_env_normalization():
+    # Mock data: 100 steps, 5 channels (OHLCV)
+    # Volume (index 4) has some large values
+    data = np.random.rand(100, 5).astype(np.float32)
+    data[:, 4] = np.array([10, 100, 1000] * 33 + [10000]).astype(np.float32)
+
+    datachannels = ["open", "high", "low", "close", "volume"]
+    pricechannels = ["open", "high", "low", "close"]
+    volumechannels = ["volume"]
+    otherchannels = []
+
+    # Test case 1: Static Normalization
+    norm_stats = {
+        "TEST": {
+            "mean": [0.5, 0.5, 0.5, 0.5, np.log1p(1000.0)],
+            "std": [0.1, 0.1, 0.1, 0.1, 1.0]
+        }
+    }
+
+    env = TradingEnvironment(
+        sequences=[data],
+        keys=["TEST_20230101"],
+        render_mode=None,
+        full_seq_len=100,
+        num_features=5,
+        num_actions=3,
+        flat_state_size=50,
+        initial_balance=1000,
+        pre_signal_len=10,
+        datachannels=datachannels,
+        slippage=0.001,
+        transaction_fee=0.001,
+        agent_session_len=50,
+        agent_history_len=10,
+        input_history_len=10,
+        pricechannels=pricechannels,
+        volumechannels=volumechannels,
+        otherchannels=otherchannels,
+        action_history_len=0,
+        inaction_penalty_ratio=0.0,
+        norm_stats=norm_stats
+    )
+
+    obs, _ = env.reset(options={"forced_index": 0})
+    # Observation contains normalized history.
+    # For index 4, it should be (log1p(volume) - mean) / std
+    # The last element of the history part of obs (first 10*5 = 50 elements)
+    # for channel 4 is at index (10-1)*5 + 4 = 49
+
+    expected_log_vol = np.log1p(data[9, 4])
+    expected_norm_vol = (expected_log_vol - norm_stats["TEST"]["mean"][4]) / (norm_stats["TEST"]["std"][4] + 1e-8)
+    expected_norm_vol = np.clip(expected_norm_vol, -5.0, 5.0)
+
+    actual_norm_vol = obs[49]
+
+    print(f"Static Norm - Expected log vol: {expected_log_vol:.4f}")
+    print(f"Static Norm - Expected norm vol: {expected_norm_vol:.4f}")
+    print(f"Static Norm - Actual norm vol: {actual_norm_vol:.4f}")
+
+    assert np.allclose(actual_norm_vol, expected_norm_vol, atol=1e-5)
+    print("Static Normalization Test Passed!")
+
+    # Test case 2: Rolling Normalization
+    env_rolling = TradingEnvironment(
+        sequences=[data],
+        keys=["TEST_20230101"],
+        render_mode=None,
+        full_seq_len=100,
+        num_features=5,
+        num_actions=3,
+        flat_state_size=50,
+        initial_balance=1000,
+        pre_signal_len=10,
+        datachannels=datachannels,
+        slippage=0.001,
+        transaction_fee=0.001,
+        agent_session_len=50,
+        agent_history_len=10,
+        input_history_len=10,
+        pricechannels=pricechannels,
+        volumechannels=volumechannels,
+        otherchannels=otherchannels,
+        action_history_len=0,
+        inaction_penalty_ratio=0.0,
+        norm_stats=None,
+        use_rolling_norm=True
+    )
+
+    obs_r, _ = env_rolling.reset(options={"forced_index": 0})
+    # Rolling norm for volume: (log1p(vol) - mean(log1p(v_window))) / std(log1p(v_window))
+    v_window = data[0:10, 4]
+    log_v_window = np.log1p(v_window)
+    v_mean = np.mean(log_v_window)
+    v_std = np.std(log_v_window) + 1e-8
+
+    expected_r_norm_vol = (np.log1p(data[9, 4]) - v_mean) / v_std
+    expected_r_norm_vol = np.clip(expected_r_norm_vol, -5.0, 5.0)
+
+    actual_r_norm_vol = obs_r[49]
+
+    print(f"Rolling Norm - Expected norm vol: {expected_r_norm_vol:.4f}")
+    print(f"Rolling Norm - Actual norm vol: {actual_r_norm_vol:.4f}")
+
+    assert np.allclose(actual_r_norm_vol, expected_r_norm_vol, atol=1e-5)
+    print("Rolling Normalization Test Passed!")
+
+    # Test case 3: Pre-normalized data (skip norm)
+    # We pre-normalize data manually
+    means = np.array([0.5, 0.5, 0.5, 0.5, 5.0])
+    stds = np.array([0.1, 0.1, 0.1, 0.1, 1.0])
+    data_pre = data.copy()
+    data_pre[:, 4] = np.log1p(data_pre[:, 4])
+    data_pre = (data_pre - means) / (stds + 1e-8)
+    data_pre = np.clip(data_pre, -5.0, 5.0)
+
+    env_pre = TradingEnvironment(
+        sequences=[data_pre],
+        keys=["TEST_20230101"],
+        render_mode=None,
+        full_seq_len=100,
+        num_features=5,
+        num_actions=3,
+        flat_state_size=50,
+        initial_balance=1000,
+        pre_signal_len=10,
+        datachannels=datachannels,
+        slippage=0.001,
+        transaction_fee=0.001,
+        agent_session_len=50,
+        agent_history_len=10,
+        input_history_len=10,
+        pricechannels=pricechannels,
+        volumechannels=volumechannels,
+        otherchannels=otherchannels,
+        action_history_len=0,
+        inaction_penalty_ratio=0.0,
+        norm_stats=None,
+        use_rolling_norm=False
+    )
+
+    obs_p, _ = env_pre.reset(options={"forced_index": 0})
+    # Should be exactly the same as data_pre[0:10]
+    expected_p_vol = data_pre[9, 4]
+    actual_p_vol = obs_p[49]
+
+    print(f"Pre-norm - Expected vol: {expected_p_vol:.4f}")
+    print(f"Pre-norm - Actual vol: {actual_p_vol:.4f}")
+
+    assert np.allclose(actual_p_vol, expected_p_vol, atol=1e-5)
+    print("Pre-normalization Test Passed!")
+
+if __name__ == "__main__":
+    try:
+        test_env_normalization()
+        print("All Environment Normalization Tests Passed!")
+    except Exception as e:
+        print(f"Tests failed: {e}")
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)


### PR DESCRIPTION
The RL environment was updated to use log-transformed volume (np.log1p) for better Z-score stability. This required updating the normalization statistics calculation logic in the training script, the live environment, and the validation script. The transformation is now consistently applied across all stages: statistic generation, data loading, and environment observation generation. We also introduced a mechanism to skip on-the-fly normalization in the environment when using pre-normalized data, which significantly improves backtesting speed in the validation script. All calculations use float32 and include protection against division-by-zero (1e-8) and weight saturation (clipping to [-5.0, 5.0]).

---
*PR created automatically by Jules for task [13256282765907490129](https://jules.google.com/task/13256282765907490129) started by @FMProducer*