### PR TITLE
Improve dynamic slot allocation for losing positions

### DIFF
--- a/third_party/rl-trading-binance/tests/test_dynamic_slots.py
+++ b/third_party/rl-trading-binance/tests/test_dynamic_slots.py
@@ -67,8 +67,8 @@ def test_total_slots_from_config(strategy):
 def test_pnl_calculation_via_freqtrade(strategy):
     """Проверка получения PnL через calc_profit (USDT)"""
     mock_trades = [
-        Mock(is_short=False, close_rate_requested=105, calc_profit=lambda rate: 50.0),  # +50 USDT
-        Mock(is_short=True, close_rate_requested=95, calc_profit=lambda rate: -20.0),   # -20 USDT
+        Mock(is_short=False, close_rate_requested=105, calc_profit=lambda rate: 50.0, stake_amount=1.0, pair="BTC/USDT"),  # +50 USDT
+        Mock(is_short=True, close_rate_requested=95, calc_profit=lambda rate: -20.0, stake_amount=1.0, pair="ETH/USDT"),   # -20 USDT
     ]
 
     with patch('freqtrade.persistence.Trade.get_open_trades', return_value=mock_trades):
@@ -94,21 +94,42 @@ def test_slot_allocation_short_profitable(strategy):
     assert strategy.max_short_slots >= 60
 
 def test_slot_allocation_both_negative(strategy):
-    """При убытках по обеим сторонам: равное распределение"""
+    """При убытках по обеим сторонам: распределение обратно пропорционально убытку"""
+    # Long -50, Short -80. Total loss 130.
+    # Long ratio = 80 / 130 = 0.615
+    # Available slots = 100 - 2*10 = 80
+    # Expected long = 10 + 80 * 0.615 = 10 + 49 = 59
     with patch.object(strategy, '_get_pnl_from_freqtrade', return_value=(-50.0, -80.0)):
         strategy._update_slot_allocation(datetime.now())
 
-    assert abs(strategy.max_long_slots - 50) <= 1
-    assert abs(strategy.max_short_slots - 50) <= 1
+    assert strategy.max_long_slots == 59
+    assert strategy.max_short_slots == 41
 
 def test_slot_allocation_both_negative_extreme(strategy):
-    """При сильно разных убытках всё равно должно быть 50/50"""
+    """При сильно разных убытках: значительное преимущество менее убыточному"""
+    # Long -500, Short -50. Total loss 550.
+    # Long ratio = 50 / 550 = 0.09
+    # Expected long = 10 + 80 * 0.09 = 10 + 7 = 17
     with patch.object(strategy, '_get_pnl_from_freqtrade', return_value=(-500.0, -50.0)):
         strategy._update_slot_allocation(datetime.now())
 
-    # Оба убыточны → равное распределение, независимо от размера убытков
-    assert abs(strategy.max_long_slots - 50) <= 1
-    assert abs(strategy.max_short_slots - 50) <= 1
+    assert strategy.max_long_slots == 17
+    assert strategy.max_short_slots == 83
+
+def test_slot_allocation_both_negative_inverse(strategy):
+    """При разных убытках - меньше слотов направлению с большим убытком"""
+    # Long теряет меньше (-47), Short теряет больше (-119)
+    # Total loss = 166. Long ratio = 119 / 166 = 0.7168
+    # Expected long = 10 + 80 * 0.7168 = 10 + 57 = 67
+    with patch.object(strategy, '_get_pnl_from_freqtrade', return_value=(-47.0, -119.0)):
+        strategy._update_slot_allocation(datetime.now())
+
+    # Лонгам должно достаться БОЛЬШЕ слотов (т.к. они теряют меньше)
+    assert strategy.max_long_slots > strategy.max_short_slots
+
+    # Проверяем примерное соотношение (119/(47+119) ≈ 0.72)
+    expected_long = 10 + int(80 * 0.7168)  # 10 + 57 = 67
+    assert abs(strategy.max_long_slots - expected_long) <= 2
 
 def test_min_slots_guarantee(strategy):
     """Минимальная гарантия соблюдается даже при экстремальном PnL"""

--- a/third_party/rl-trading-binance/user_data/strategies/CustomD3QNStrategy4z.py
+++ b/third_party/rl-trading-binance/user_data/strategies/CustomD3QNStrategy4z.py
@@ -640,17 +640,32 @@ class CustomD3QNStrategy4z(IStrategy):
 
         pnl_long, pnl_short = self._get_pnl_from_freqtrade()
 
-        # УЛУЧШЕННАЯ логика распределения
+        # === УЛУЧШЕННАЯ ЛОГИКА РАСПРЕДЕЛЕНИЯ ===
         if pnl_long > 0 and pnl_short < 0:
             long_ratio = 0.7
+            reason = "Long profitable, Short losing"
         elif pnl_short > 0 and pnl_long < 0:
             long_ratio = 0.3
+            reason = "Short profitable, Long losing"
         elif pnl_long > 0 and pnl_short > 0:
-            # Оба прибыльны → пропорционально вкладу
             long_ratio = pnl_long / (pnl_long + pnl_short)
+            reason = f"Both profitable (L:{pnl_long:.0f} S:{pnl_short:.0f})"
+        elif pnl_long < 0 and pnl_short < 0:
+            # ОБА УБЫТОЧНЫ → ИНВЕРТИРОВАННАЯ ПРОПОРЦИЯ
+            loss_long = abs(pnl_long)
+            loss_short = abs(pnl_short)
+            total_loss = loss_long + loss_short
+
+            if total_loss > 0:
+                # Инвертируем: большему убытку - меньше слотов
+                long_ratio = loss_short / total_loss
+                reason = f"Both losing - inverse allocation (L:-{loss_long:.0f} S:-{loss_short:.0f})"
+            else:
+                long_ratio = 0.5
+                reason = "Both at zero"
         else:
-            # Оба убыточны или нулевые → равное распределение
             long_ratio = 0.5
+            reason = "One side at zero"
 
         available = self.total_slots - 2 * self.min_slots_per_side
         if available < 0:
@@ -662,7 +677,7 @@ class CustomD3QNStrategy4z(IStrategy):
             self.max_short_slots = self.total_slots - self.max_long_slots
 
         self.slot_history.append((current_time, self.max_long_slots, self.max_short_slots, pnl_long, pnl_short))
-        logger.info(f"🎰 SLOTS: L={self.max_long_slots} ({pnl_long:+.1f} USDT) | S={self.max_short_slots} ({pnl_short:+.1f} USDT)")
+        logger.info(f"🎰 SLOTS: L={self.max_long_slots} ({pnl_long:+.1f} USDT) | S={self.max_short_slots} ({pnl_short:+.1f} USDT) | {reason}")
 
     def _normalize_q_value(self, q_value: float, model_name: str) -> float:
         """


### PR DESCRIPTION
This change improves the dynamic slot allocation logic in the CustomD3QNStrategy4z strategy. When both Long and Short positions are currently in a loss, the system now distributes available trading slots inversely proportional to the magnitude of the losses. This means the side that is losing less money gets more slots, while the side with heavier losses is "punished" by receiving fewer slots.

Key changes:
- Updated `_update_slot_allocation` in `CustomD3QNStrategy4z.py` with the new logic.
- Added descriptive reasons to the slot allocation logs for better observability.
- Added `test_slot_allocation_both_negative_inverse` to `test_dynamic_slots.py`.
- Updated `test_slot_allocation_both_negative` and `test_slot_allocation_both_negative_extreme` to match the new behavior.
- Fixed a bug in `test_pnl_calculation_via_freqtrade` where missing mock attributes caused incorrect PnL calculation.

---
*PR created automatically by Jules for task [1763766571243683810](https://jules.google.com/task/1763766571243683810) started by @FMProducer*