### PR TITLE
Implement On-Demand Dynamic Slot Allocation

### DIFF
--- a/third_party/rl-trading-binance/tests/test_dynamic_slots.py
+++ b/third_party/rl-trading-binance/tests/test_dynamic_slots.py
@@ -30,6 +30,7 @@ sys.modules['freqtrade.persistence'] = mock_persistence
 @pytest.fixture
 def strategy_config():
     return {
+        'runmode': 'dry_run',
         'max_open_trades': 100,  # ИСПОЛЬЗУЕМ ГЛОБАЛЬНЫЙ ПАРАМЕТР
         'cpu_threads': 4,
         'rl_enable_long_1': True,
@@ -166,3 +167,25 @@ def test_slot_history_saved(strategy):
     assert len(entry) == 5  # (timestamp, long_slots, short_slots, pnl_long, pnl_short)
     assert entry[3] == 100.0  # pnl_long
     assert entry[4] == 50.0   # pnl_short
+
+def test_on_demand_mode(strategy):
+    """При update_interval_sec == 0 (On-Demand) обновление происходит при каждом вызове"""
+    strategy.slot_update_interval = 0
+    strategy.last_slot_update = datetime.now() - timedelta(seconds=1) # Прошлый апдейт 1 сек назад
+
+    with patch.object(strategy, '_update_slot_allocation') as mock_update:
+        # Симулируем confirm_trade_entry
+        with patch('freqtrade.persistence.Trade.get_trades') as mock_trades:
+            # Mock the query object returned by get_trades
+            mock_query = MagicMock()
+            mock_query.all.return_value = []
+            # Make sure directional timeout is skipped by returning None for last_trade
+            mock_query.order_by.return_value.first.return_value = None
+            mock_trades.return_value = mock_query
+
+            # Первый вызов
+            strategy.confirm_trade_entry("BTC/USDT", "limit", 1.0, 50000.0, "gtc", datetime.now(), "tag", "long")
+            # Второй вызов (через мгновение)
+            strategy.confirm_trade_entry("ETH/USDT", "limit", 1.0, 2500.0, "gtc", datetime.now(), "tag", "long")
+
+    assert mock_update.call_count == 2

--- a/third_party/rl-trading-binance/user_data/config_rl4z.json
+++ b/third_party/rl-trading-binance/user_data/config_rl4z.json
@@ -19,7 +19,7 @@
     "dynamic_slots": {
         "enabled": true,
         "min_slots_per_side": 10,
-        "update_interval_sec": 300
+        "update_interval_sec": 0
     },
     "api_server": {
         "enabled": true,

--- a/third_party/rl-trading-binance/user_data/strategies/CustomD3QNStrategy4z.py
+++ b/third_party/rl-trading-binance/user_data/strategies/CustomD3QNStrategy4z.py
@@ -858,9 +858,16 @@ class CustomD3QNStrategy4z(IStrategy):
 
             # === ДИНАМИЧЕСКОЕ ОБНОВЛЕНИЕ СЛОТОВ ===
             if self.dynamic_slots_enabled:
-                if self.last_slot_update is None or (current_time - self.last_slot_update).total_seconds() > self.slot_update_interval:
+                if self.slot_update_interval == 0:
+                    # On-Demand mode: обновляем при каждом входе
                     self._update_slot_allocation(current_time)
                     self.last_slot_update = current_time
+                else:
+                    # Таймер mode: обновляем по интервалу
+                    if self.last_slot_update is None or \
+                       (current_time - self.last_slot_update).total_seconds() > self.slot_update_interval:
+                        self._update_slot_allocation(current_time)
+                        self.last_slot_update = current_time
             else:
                 # Фиксированные лимиты (legacy)
                 if self.total_slots > 0:


### PR DESCRIPTION
This change implements an "On-Demand" mode for the dynamic slot allocation system in `CustomD3QNStrategy4z`. By setting `update_interval_sec` to 0 in the configuration, the strategy now recalculates slot distribution between Long and Short positions every time a new trade entry is considered. This ensures that the most recent portfolio PnL (both realized and unrealized) is used to protect against opening further positions in losing directions. 

Included is a new unit test verifying that updates occur on every call in this mode, along with necessary fixes to the test environment setup.

---
*PR created automatically by Jules for task [4534039327612721010](https://jules.google.com/task/4534039327612721010) started by @FMProducer*