### PR TITLE
Implement Improved Logic V2 for Dynamic Slot Allocation

### DIFF
--- a/third_party/rl-trading-binance/tests/test_dynamic_slots.py
+++ b/third_party/rl-trading-binance/tests/test_dynamic_slots.py
@@ -39,9 +39,9 @@ def strategy_config():
         'rl_enable_short_2': True,
         'dynamic_slots': {
             'enabled': True,
-            'min_slots_per_side': 10,
-            'update_interval_sec': 300
-            # БЕЗ total_slots — берётся из max_open_trades
+            'min_slots_per_side': 5,
+            'update_interval_sec': 300,
+            'aggression_factor': 1.5
         },
         'rl_ensemble': {
             'epsilon_threshold': 0.15,
@@ -79,58 +79,66 @@ def test_pnl_calculation_via_freqtrade(strategy):
     assert pnl_short == -20.0
 
 def test_slot_allocation_long_profitable(strategy):
-    """При прибыльных лонгах и убыточных шортах: 70% слотов лонгам"""
+    """При прибыльных лонгах и убыточных шортах: V2 logic с aggression_factor"""
+    # pnl_long = 250, pnl_short = -100.
+    # profit_long = 250, loss_short = 100, total = 350
+    # penalty_ratio = (100/350)**1.5 ≈ 0.1527
+    # long_ratio = 0.8 + 0.15 * 0.1527 ≈ 0.8229
+    # available = 100 - 2*5 = 90
+    # Expected long = 5 + int(90 * 0.8229) = 5 + 74 = 79
     with patch.object(strategy, '_get_pnl_from_freqtrade', return_value=(250.0, -100.0)):
         strategy._update_slot_allocation(datetime.now())
 
-    assert strategy.max_long_slots > strategy.max_short_slots
-    assert strategy.max_long_slots >= 60  # ~70% от 100 минус минимум
+    assert strategy.max_long_slots == 79
+    assert strategy.max_short_slots == 21
 
 def test_slot_allocation_short_profitable(strategy):
-    """При прибыльных шортах и убыточных лонгах: 70% слотов шортам"""
+    """При прибыльных шортах и убыточных лонгах: V2 logic с aggression_factor"""
+    # pnl_long = -150, pnl_short = 300.
+    # profit_short = 300, loss_long = 150, total = 450
+    # penalty_ratio = (150/450)**1.5 ≈ 0.1924
+    # long_ratio = 0.2 - 0.15 * 0.1924 ≈ 0.1711
+    # Expected long = 5 + int(90 * 0.1711) = 5 + 15 = 20
     with patch.object(strategy, '_get_pnl_from_freqtrade', return_value=(-150.0, 300.0)):
         strategy._update_slot_allocation(datetime.now())
 
-    assert strategy.max_short_slots > strategy.max_long_slots
-    assert strategy.max_short_slots >= 60
+    assert strategy.max_long_slots == 20
+    assert strategy.max_short_slots == 80
 
 def test_slot_allocation_both_negative(strategy):
     """При убытках по обеим сторонам: распределение обратно пропорционально убытку"""
     # Long -50, Short -80. Total loss 130.
-    # Long ratio = 80 / 130 = 0.615
-    # Available slots = 100 - 2*10 = 80
-    # Expected long = 10 + 80 * 0.615 = 10 + 49 = 59
+    # Long ratio = 80 / 130 = 0.6153
+    # Available slots = 100 - 2*5 = 90
+    # Expected long = 5 + int(90 * 0.6153) = 5 + 55 = 60
     with patch.object(strategy, '_get_pnl_from_freqtrade', return_value=(-50.0, -80.0)):
         strategy._update_slot_allocation(datetime.now())
 
-    assert strategy.max_long_slots == 59
-    assert strategy.max_short_slots == 41
+    assert strategy.max_long_slots == 60
+    assert strategy.max_short_slots == 40
 
 def test_slot_allocation_both_negative_extreme(strategy):
     """При сильно разных убытках: значительное преимущество менее убыточному"""
     # Long -500, Short -50. Total loss 550.
-    # Long ratio = 50 / 550 = 0.09
-    # Expected long = 10 + 80 * 0.09 = 10 + 7 = 17
+    # Long ratio = 50 / 550 = 0.0909
+    # Expected long = 5 + int(90 * 0.0909) = 5 + 8 = 13
     with patch.object(strategy, '_get_pnl_from_freqtrade', return_value=(-500.0, -50.0)):
         strategy._update_slot_allocation(datetime.now())
 
-    assert strategy.max_long_slots == 17
-    assert strategy.max_short_slots == 83
+    assert strategy.max_long_slots == 13
+    assert strategy.max_short_slots == 87
 
 def test_slot_allocation_both_negative_inverse(strategy):
     """При разных убытках - меньше слотов направлению с большим убытком"""
     # Long теряет меньше (-47), Short теряет больше (-119)
     # Total loss = 166. Long ratio = 119 / 166 = 0.7168
-    # Expected long = 10 + 80 * 0.7168 = 10 + 57 = 67
+    # Expected long = 5 + int(90 * 0.7168) = 5 + 64 = 69
     with patch.object(strategy, '_get_pnl_from_freqtrade', return_value=(-47.0, -119.0)):
         strategy._update_slot_allocation(datetime.now())
 
     # Лонгам должно достаться БОЛЬШЕ слотов (т.к. они теряют меньше)
     assert strategy.max_long_slots > strategy.max_short_slots
-
-    # Проверяем примерное соотношение (119/(47+119) ≈ 0.72)
-    expected_long = 10 + int(80 * 0.7168)  # 10 + 57 = 67
-    assert abs(strategy.max_long_slots - expected_long) <= 2
+    assert strategy.max_long_slots == 69
 
 def test_min_slots_guarantee(strategy):
     """Минимальная гарантия соблюдается даже при экстремальном PnL"""

--- a/third_party/rl-trading-binance/user_data/config_rl4z.json
+++ b/third_party/rl-trading-binance/user_data/config_rl4z.json
@@ -18,8 +18,9 @@
     "rl_enable_short_2": true,
     "dynamic_slots": {
         "enabled": true,
-        "min_slots_per_side": 10,
-        "update_interval_sec": 0
+        "min_slots_per_side": 5,
+        "update_interval_sec": 0,
+        "aggression_factor": 1.5
     },
     "api_server": {
         "enabled": true,

--- a/third_party/rl-trading-binance/user_data/strategies/CustomD3QNStrategy4z.py
+++ b/third_party/rl-trading-binance/user_data/strategies/CustomD3QNStrategy4z.py
@@ -172,6 +172,7 @@ class CustomD3QNStrategy4z(IStrategy):
         self.dynamic_slots_enabled = self.dynamic_slots_cfg.get('enabled', False)
         self.total_slots = config.get('max_open_trades', 100)  # Используем глобальный параметр
         self.min_slots_per_side = self.dynamic_slots_cfg.get('min_slots_per_side', 10)
+        self.aggression_factor = self.dynamic_slots_cfg.get('aggression_factor', 1.5)
         self.slot_update_interval = self.dynamic_slots_cfg.get('update_interval_sec', 300)
 
         self.max_long_slots = self.total_slots // 2 if self.total_slots > 0 else 50
@@ -660,13 +661,27 @@ class CustomD3QNStrategy4z(IStrategy):
 
         pnl_long, pnl_short = self._get_pnl_from_freqtrade()
 
-        # === УЛУЧШЕННАЯ ЛОГИКА РАСПРЕДЕЛЕНИЯ ===
+        # === УЛУЧШЕННАЯ ЛОГИКА V2 ===
         if pnl_long > 0 and pnl_short < 0:
-            long_ratio = 0.7
-            reason = "Long profitable, Short losing"
+            # Пропорциональное наказание убыточного направления
+            profit_long = pnl_long
+            loss_short = abs(pnl_short)
+            total = profit_long + loss_short
+
+            penalty_ratio = (loss_short / total) ** self.aggression_factor
+            long_ratio = 0.8 + 0.15 * penalty_ratio
+            reason = f"Long profitable (+{pnl_long:.0f}), Short losing (-{loss_short:.0f})"
+
         elif pnl_short > 0 and pnl_long < 0:
-            long_ratio = 0.3
-            reason = "Short profitable, Long losing"
+            # Зеркально
+            profit_short = pnl_short
+            loss_long = abs(pnl_long)
+            total = profit_short + loss_long
+
+            penalty_ratio = (loss_long / total) ** self.aggression_factor
+            long_ratio = 0.2 - 0.15 * penalty_ratio
+            reason = f"Short profitable (+{pnl_short:.0f}), Long losing (-{loss_long:.0f})"
+
         elif pnl_long > 0 and pnl_short > 0:
             long_ratio = pnl_long / (pnl_long + pnl_short)
             reason = f"Both profitable (L:{pnl_long:.0f} S:{pnl_short:.0f})"
@@ -686,6 +701,9 @@ class CustomD3QNStrategy4z(IStrategy):
         else:
             long_ratio = 0.5
             reason = "One side at zero"
+
+        # Ограничиваем в разумных пределах
+        long_ratio = max(0.05, min(0.95, long_ratio))
 
         available = self.total_slots - 2 * self.min_slots_per_side
         if available < 0:


### PR DESCRIPTION
This change implements an improved dynamic slot allocation logic (V2) in the `CustomD3QNStrategy4z` strategy.

Key changes:
1. **Strategy Logic**: The `_update_slot_allocation` method now uses an `aggression_factor` (default 1.5) to calculate a `penalty_ratio` when one side is profitable and the other is losing. This penalizes the losing side more heavily.
2. **Safety**: Added clamping for `long_ratio` between 0.05 and 0.95.
3. **Configuration**: Updated `user_data/config_rl4z.json` with the new `aggression_factor` and changed `min_slots_per_side` from 10 to 5.
4. **Testing**: Updated `third_party/rl-trading-binance/tests/test_dynamic_slots.py` to verify the new mathematical logic and defaults.

The changes were verified with unit tests and ensure a more reactive and aggressive redistribution of trading slots based on real-time performance.

---
*PR created automatically by Jules for task [1501750793210261347](https://jules.google.com/task/1501750793210261347) started by @FMProducer*