### PR TITLE
Update advantage statistics collection logic in CustomD3QNStrategy4z

### DIFF
--- a/third_party/rl-trading-binance/user_data/strategies/CustomD3QNStrategy4z.py
+++ b/third_party/rl-trading-binance/user_data/strategies/CustomD3QNStrategy4z.py
@@ -538,11 +538,26 @@ class CustomD3QNStrategy4z(IStrategy):
         return results
 
     def _collect_adv_stats(self, name: str, adv_array: np.ndarray):
+        """
+        Сбор статистики advantage для автоподбора q_min/q_max.
+        Вместо одного последнего значения используем все положительные
+        значения из adv_array и храним короткое скользящее окно.
+        """
         if name not in self.adv_history:
-            self.adv_history[name] = deque(maxlen=50000)
-        # Берем последнее значение (текущая свеча)
-        if len(adv_array) > 0:
-            self.adv_history[name].append(float(adv_array[-1]))
+            # Примерно 5 минут истории:
+            # при большом количестве пар метод вызывается очень часто,
+            # поэтому 1280 элементов дают короткое, но репрезентативное окно.
+            self.adv_history[name] = deque(maxlen=1280)
+
+        if adv_array is None or len(adv_array) == 0:
+            return
+
+        # Берем только положительные advantage (сигналы выше нуля)
+        # и добавляем их в общую историю по данной модели.
+        pos_arr = np.asarray(adv_array, dtype=float)
+        pos_arr = pos_arr[pos_arr > 0.0]
+        if pos_arr.size > 0:
+            self.adv_history[name].extend(pos_arr.tolist())
 
     def update_normalization_config(self):
         try:


### PR DESCRIPTION
The `_collect_adv_stats` method in `CustomD3QNStrategy4z.py` was updated to improve the auto-tuning of `q_min`/`q_max`. 

Key changes:
1. **Shorter History:** The `maxlen` for the `adv_history` deque was changed from 50,000 to 1,280. This provides a more recent and representative distribution of advantage values (roughly 5 minutes of data across multiple pairs).
2. **Portfolio-wide Collection:** Instead of appending only the last value of the `adv_array`, the method now filters for all positive advantage values (`> 0.0`) and adds them all to the history using `extend()`. This captures the distribution across the entire portfolio at each inference step.
3. **Robustness:** Added checks for `None` or empty `adv_array` and ensured input is treated as a NumPy array.
4. **Documentation:** Added a docstring explaining the logic and the rationale for the window size.

These changes are designed to provide a better basis for percentile-based auto-tuning of confidence thresholds.

---
*PR created automatically by Jules for task [13401884516268957568](https://jules.google.com/task/13401884516268957568) started by @FMProducer*