### PR TITLE
Specialist Modes and Dynamic Action Space Refactor

### DIFF
--- a/third_party/rl-trading-binance/trading_environment.py
+++ b/third_party/rl-trading-binance/trading_environment.py
@@ -108,6 +108,7 @@ class TradingEnvironment(gym.Env):
         seed: Optional[int] = None,
         filter_direction: Optional[str] = None,
         allowed_directions: Optional[List[str]] = None,
+        agent_mode: str = "UNIVERSAL", # "LONG_ONLY", "SHORT_ONLY", "MIRROR_SHORT"
         **kwargs,
     ) -> None:
         if not sequences:
@@ -224,7 +225,13 @@ class TradingEnvironment(gym.Env):
         self.volumechannels = volumechannels
         self.otherchannels = otherchannels
         self.action_history_len = action_history_len
-        self.num_actions = num_actions
+
+        self.agent_mode = agent_mode
+        if self.agent_mode in ["LONG_ONLY", "SHORT_ONLY", "MIRROR_SHORT"]:
+            self.num_actions = 2
+        else:
+            self.num_actions = 3 # Universal: 0-Stay, 1-Long, 2-Short
+
         self.inaction_penalty_ratio = inaction_penalty_ratio
         self.time_sl_penalty_ratio = time_sl_penalty_ratio
         self.backtest_mode = backtest_mode
@@ -287,7 +294,7 @@ class TradingEnvironment(gym.Env):
         # Cache frequently used channel index
         self.close_idx = self.datachannels.index("close")
 
-        self.history_vector_size = num_actions * self.action_history_len
+        self.history_vector_size = self.num_actions * self.action_history_len
         # Validate sequence shape
         # Support both (L, C) and (C, L, 1) formats
         expected_shape = (full_seq_len, num_features)
@@ -300,7 +307,7 @@ class TradingEnvironment(gym.Env):
                 raise ValueError(f"Expected sequence shape {expected_shape}, but got {self.sequences[0].shape}")
 
         # Define observation and action spaces
-        self.action_space = spaces.Discrete(num_actions)
+        self.action_space = spaces.Discrete(self.num_actions)
         if self.cnn_format:
             # For CNN: (num_features + extras + action_history_onehot, agent_history_len)
             # We will treat extras and action history as additional channels
@@ -315,7 +322,7 @@ class TradingEnvironment(gym.Env):
             # FIX: Ensure buffer size matches actual data generation logic
             # Calculate expected size based on what _get_obs actually produces
             # Use local argument or self.num_features (now saved)
-            real_data_size = (num_features * agent_history_len) + 4 + (num_actions * action_history_len)
+            real_data_size = (num_features * agent_history_len) + 4 + (self.num_actions * action_history_len)
             self.observation_space = spaces.Box(low=-np.inf, high=np.inf, shape=(real_data_size,), dtype=np.float32)
 
         # PERFORMANCE: Pre-allocate reusable observation buffer
@@ -519,43 +526,45 @@ class TradingEnvironment(gym.Env):
             self._render_human(info, first=True)
         return obs, info
 
+    def _get_direction_from_action(self, action: int) -> int:
+        if self.agent_mode == "SHORT_ONLY":
+            return -1 if action == 1 else 0
+        if self.agent_mode in ["LONG_ONLY", "MIRROR_SHORT"]:
+            return 1 if action == 1 else 0
+        # UNIVERSAL mode: 0-Stay, 1-Long, 2-Short
+        return {0: 0, 1: 1, 2: -1}.get(action, 0)
+
     def step(self, action: int) -> Tuple[np.ndarray, float, bool, bool, Dict[str, Any]]:
-        """Executes a single time step in the environment.
-
-        This method processes the agent's action, updates the environment's
-        state, and calculates the reward. The state transition from `s_t` to
-        `s_{t+1}` is determined by the market data and the agent's action `a_t`.
-        The reward `r_t` is calculated based on the resulting change in
-        portfolio value and any applicable shaped rewards or penalties.
-
-        Args:
-            action (int): The action selected by the agent.
-
-        Returns:
-            Tuple[np.ndarray, float, bool, bool, Dict[str, Any]]: A tuple
-                containing the next observation, the reward, a flag indicating
-                if the episode has terminated, a flag indicating if the episode
-                has been truncated, and an info dictionary.
-        """
+        """Executes a single time step in the environment."""
         assert self.current_seq is not None, "reset() must be called before step()"
 
-        # Action Masking for Specialists
+        # Action Mapping
         penalty = 0.0
+
+        # Determine target_action: 0=HOLD, 1=LONG, 2=SHORT
+        if self.agent_mode == "SHORT_ONLY":
+            target_action = 2 if action == 1 else 0
+        elif self.agent_mode in ["LONG_ONLY", "MIRROR_SHORT"]:
+            target_action = 1 if action == 1 else 0
+        else:
+            target_action = action
+
+        # Compatibility with existing filter_direction logic
         if self.filter_direction == "SHORT":
-            # If mirrored, action 1 is the intended action (acting as Short), action 2 is prohibited (acting as Long)
             if self.invert_data:
-                if action == 2:
-                    action = 0
+                if target_action == 2:
+                    target_action = 0
                     penalty = -0.01
             else:
-                if action == 1:
-                    action = 0
+                if target_action == 1:
+                    target_action = 0
                     penalty = -0.01
         elif self.filter_direction == "LONG":
-            if action == 2:
-                action = 0
+            if target_action == 2:
+                target_action = 0
                 penalty = -0.01
 
+        action = target_action
         prev_position = self.position
 
         # Определяем действие "закрыть" (3 для num_actions=4, или -1 если close отключен)
@@ -1176,6 +1185,15 @@ class TradingEnvironment(gym.Env):
                 info dictionary with detailed trade information.
         """
         assert self.current_seq is not None, "reset() must be called before backtest_step()"
+
+        # Action Mapping
+        if self.agent_mode == "SHORT_ONLY":
+            action = 2 if action == 1 else 0
+        elif self.agent_mode in ["LONG_ONLY", "MIRROR_SHORT"]:
+            action = 1 if action == 1 else 0
+        else:
+            # Universal mode
+            pass
 
         self.last_step = self.step_idx == self.agent_session_len - 1
         if self.last_step:

--- a/third_party/rl-trading-binance/train.py
+++ b/third_party/rl-trading-binance/train.py
@@ -663,7 +663,38 @@ def run_training_session(
     """
     Runs a complete training and validation session for a given dataset.
     """
+    # Handle AGENT_MODE to control allowed_directions
+    agent_mode = "UNIVERSAL"
+    if cfg_mod is not None and hasattr(cfg_mod, "AGENT_MODE"):
+        agent_mode = cfg_mod.AGENT_MODE
+    else:
+        agent_mode = getattr(cfg, "AGENT_MODE", "UNIVERSAL")
+
+    # Detection of MIRROR_SHORT from data if not explicitly set
+    is_inverted = False
+    if len(train_sequences) > 0:
+        close_idx = cfg.data.datachannels.index("close")
+        sample_asset = train_keys[0].split('_')[0]
+        asset_stats = norm_stats.get(sample_asset)
+        if asset_stats:
+            avg_price = asset_stats['mean'][close_idx]
+            if 0 < avg_price < 0.001:
+                is_inverted = True
+                logging.info(f"Detected potential inverted data for {sample_asset} (mean price: {avg_price:.6f})")
+
+    if is_inverted and agent_mode == "UNIVERSAL":
+        logging.info("Setting agent_mode to MIRROR_SHORT due to detected inverted data.")
+        agent_mode = "MIRROR_SHORT"
+
+    # Handle Specialist num_actions and update config
+    if agent_mode in ["LONG_ONLY", "SHORT_ONLY", "MIRROR_SHORT"]:
+        num_actions = 2
+    else:
+        num_actions = 3
     
+    cfg.market.num_actions = num_actions
+    logging.info(f"Set num_actions to {num_actions} for agent_mode {agent_mode}")
+
     # --- MC-dropout: ищем внешний объект `mc_dropout_cfg` или создаём пустышку ---
     mc_cfg = getattr(cfg_mod, "mc_dropout_cfg", type("obj", (), {})())
 
@@ -762,6 +793,9 @@ def run_training_session(
         allowed_dirs = ["SHORT"]
     elif agent_mode == "LONG_ONLY":
         filter_dir = "LONG"
+        allowed_dirs = ["LONG"]
+    elif agent_mode == "MIRROR_SHORT":
+        filter_dir = "LONG" # Trades Long on mirrored data
         allowed_dirs = ["LONG"]
 
     env_kwargs = {

--- a/third_party/rl-trading-binance/validate_model.py
+++ b/third_party/rl-trading-binance/validate_model.py
@@ -366,13 +366,23 @@ def validate(config_path, checkpoint_path, out_dir, episode_num, args):
                 val_seqs[i][h_idx] = val_seqs[i][l_idx]
                 val_seqs[i][l_idx] = temp
 
+    # Determine num_actions based on mode
+    if raw_mode in ["LONG_ONLY", "SHORT_ONLY", "MIRROR_SHORT"]:
+        num_actions = 2
+    else:
+        num_actions = 3
+
+    cfg.market.num_actions = num_actions
+    logger.info(f"Set num_actions to {num_actions} for validation mode {raw_mode}")
+
     env_kwargs = {
         "sequences": val_seqs,
         "keys": val_keys,
         "stats": norm_stats,
         "full_seq_len": cfg.seq.full_seq_len,
         "num_features": val_seqs[0].shape[0],
-        "num_actions": cfg.market.num_actions,
+        "num_actions": num_actions,
+        "agent_mode": raw_mode,
         "initial_balance": cfg.market.initial_balance,
         "pre_signal_len": cfg.seq.pre_signal_len,
         "datachannels": cfg.data.datachannels,


### PR DESCRIPTION
Implemented the requested specialist modes for the reinforcement learning trading bot. 

Key changes:
1. **TradingEnvironment**: Now supports `agent_mode` parameter. For specialist modes (`LONG_ONLY`, `SHORT_ONLY`, `MIRROR_SHORT`), the action space is restricted to 2 (HOLD/TRADE). In `SHORT_ONLY` mode, action 1 is mapped to a Short position (-1). In `MIRROR_SHORT` and `LONG_ONLY`, it maps to Long (1). `UNIVERSAL` mode uses 3 actions.
2. **PnL & Risk Management**: Unified PnL calculation using `((current_price - entry_price) / entry_price) * position` for mathematical correctness in both directions. TSL logic correctly tracks peaks/troughs depending on position direction.
3. **Training & Validation Scripts**: Both `train.py` and `validate_model.py` now dynamically update `cfg.market.num_actions` based on the detected or configured `AGENT_MODE` before initializing the Agent or Environment. This prevents weight mismatches in the neural network's output layer.
4. **Data Detection**: `train.py` now includes a heuristic to detect inverted market data by checking mean prices in normalization statistics, automatically enabling `MIRROR_SHORT` mode if appropriate.

Verification:
Successfully ran a smoke test script verifying all 4 modes, their resulting action counts, observation vector sizes, and position mappings.


---
*PR created automatically by Jules for task [12921676066082489612](https://jules.google.com/task/12921676066082489612) started by @FMProducer*