### PR TITLE
Transition to side-specific base thresholds in dynamic epsilon calculation

### DIFF
--- a/third_party/rl-trading-binance/user_data/strategies/CustomD3QNStrategy4z.py
+++ b/third_party/rl-trading-binance/user_data/strategies/CustomD3QNStrategy4z.py
@@ -785,8 +785,9 @@ class CustomD3QNStrategy4z(IStrategy):
 
             # Linear sensitivity: epsilon_target = epsilon_0 * (1 + k * DD) — раздельно для long/short
             k = 6.0
-            epsilon_target_long = self.epsilon_threshold * (1.0 + k * dd_long)
-            epsilon_target_short = self.epsilon_threshold * (1.0 + k * dd_short)
+            # Scale dynamic targets around side-specific base thresholds
+            epsilon_target_long = self.epsilon_threshold_long * (1.0 + k * dd_long)
+            epsilon_target_short = self.epsilon_threshold_short * (1.0 + k * dd_short)
 
             # Clamp epsilon_target into [0.1, 1.0] — как было, раздельно для long/short
             epsilon_target_long = float(min(max(epsilon_target_long, 0.1), 1.0))


### PR DESCRIPTION
Updated the `_update_dynamic_epsilon` method in `CustomD3QNStrategy4z` to utilize separate base thresholds for Long and Short directions (`self.epsilon_threshold_long` and `self.epsilon_threshold_short`). This change ensures that dynamic epsilon targets are scaled relative to their respective side-specific baseline thresholds, while keeping the rest of the logic (drawdown calculation, clamping to [0.1, 1.0], and EMA smoothing) intact. Verified with existing tests and code review.

---
*PR created automatically by Jules for task [10496949878777019284](https://jules.google.com/task/10496949878777019284) started by @FMProducer*