### PR TITLE
Update PnL-Diff formula and enforce snake_case in optimize_balance.py

### DIFF
--- a/scripts/optimize_balance.py
+++ b/scripts/optimize_balance.py
@@ -192,8 +192,9 @@ class BalanceOptimizer:
         pnl_s = float(-future_ret[mask_s].sum())
 
         denom = abs(pnl_l) + abs(pnl_s)
-        # PnL-Diff measures the relative profit imbalance between sides
-        p_diff = abs(pnl_l - pnl_s) / denom if denom > 1e-6 else 1.0
+        # PnL-Diff: насколько нейтральна сумма PnL двух сторон
+        # |PnL_L + PnL_S| / (|PnL_L| + |PnL_S|)
+        p_diff = abs(pnl_l + pnl_s) / denom if denom > 1e-6 else 1.0
 
         return v_diff, p_diff, total
 
@@ -227,8 +228,8 @@ class BalanceOptimizer:
         best_l, best_s, v_diff, p_diff, total = candidates[0]
 
         print("\nBest balanced configuration:")
-        print(f"  epsilonthreshold_long  = {best_l:.3f}")
-        print(f"  epsilonthreshold_short = {best_s:.3f}")
+        print(f"  epsilon_threshold_long  = {best_l:.3f}")
+        print(f"  epsilon_threshold_short = {best_s:.3f}")
         print(f"  V-Diff  = {v_diff:.2%}")
         print(f"  PnL-Diff = {p_diff:.2%}")
         print(f"  Total signals = {total}")


### PR DESCRIPTION
The PnL-Diff formula in `scripts/optimize_balance.py` has been updated to correctly measure market neutrality. Additionally, labels in the script's output were converted to snake_case (`epsilon_threshold_long` and `epsilon_threshold_short`) to ensure consistency with the project's naming conventions. Verification was performed by executing the script in a mock environment.

---
*PR created automatically by Jules for task [2172261683221405208](https://jules.google.com/task/2172261683221405208) started by @FMProducer*