### PR TITLE
Fix Numba JIT and SuperTrend Look-ahead Bias

### DIFF
--- a/third_party/rl-trading-binance/user_data/strategies/CustomD3QNStrategy4z.py
+++ b/third_party/rl-trading-binance/user_data/strategies/CustomD3QNStrategy4z.py
@@ -77,8 +77,8 @@ logger = logging.getLogger(__name__)
 
 
 # --- NUMBA JIT SUPERTREND LOOP ---
-# Выносим цикл из класса для LLVM компиляции. cache=True убирает warmup penalty.
-@njit(cache=True)
+# Выносим цикл из класса для LLVM компиляции. cache=False fixes "No module named '<dynamic>'"
+@njit(cache=False)
 def _numba_supertrend_loop(close_p: np.ndarray, upperband_p: np.ndarray, lowerband_p: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
     size = len(close_p)
     st = np.zeros(size, dtype=np.float64)
@@ -668,7 +668,8 @@ class CustomD3QNStrategy4z(IStrategy):
 
         out = pd.DataFrame(index=df.index)
         out['st'] = st
-        out['st_dir'] = direction
+        # Shift direction by 1 to avoid look-ahead bias (using only closed candle data)
+        out['st_dir'] = pd.Series(direction, index=df.index).shift(1).fillna(0).astype(np.int8)
         return out
 
     def populate_indicators(self, dataframe: DataFrame, metadata: dict) -> DataFrame:


### PR DESCRIPTION
This PR addresses a technical bug in the Numba JIT compilation and a logical error in the SuperTrend indicator calculation.

1. **Numba JIT Fix**: The `@njit(cache=True)` decorator was causing "No module named '<dynamic>'" errors during strategy reloads. Changing it to `cache=False` ensures stability at the cost of a minor warmup delay.
2. **Look-ahead Bias Fix**: The SuperTrend direction was using the current candle's close price to determine the regime, which introduces look-ahead bias during backtesting. By shifting the direction by 1, we ensure that the regime filter only uses data from completed candles.

---
*PR created automatically by Jules for task [17630361097084129242](https://jules.google.com/task/17630361097084129242) started by @FMProducer*