### PR TITLE
Optimize Normalization with NumPy and Fix ddof in CustomD3QNStrategy4z

### DIFF
--- a/third_party/rl-trading-binance/user_data/strategies/CustomD3QNStrategy4z.py
+++ b/third_party/rl-trading-binance/user_data/strategies/CustomD3QNStrategy4z.py
@@ -293,11 +293,20 @@ class CustomD3QNStrategy4z(IStrategy):
                 df = self.dp.get_pair_dataframe(pair, self.timeframe)
                 if df is None or len(df) < 180: continue
                 raw_cols = ['open', 'high', 'low', 'close', 'volume']
-                z_slice = df[raw_cols].iloc[-180:].copy()
-                z_slice['volume'] = np.log1p(z_slice['volume'])
-                mean, std = z_slice.mean().values, z_slice.std().values + 1e-6
-                normalized = (z_slice.iloc[-90:].values - mean) / std
-                
+
+                # Извлекаем сырой numpy массив для скорости
+                arr = df[raw_cols].iloc[-180:].values.astype(np.float32)
+
+                # In-place логарифмирование объема (5-я колонка, индекс 4)
+                arr[:, 4] = np.log1p(arr[:, 4])
+
+                # Математически точный расчет mean и std (строго ddof=0, как при обучении)
+                mean = arr.mean(axis=0)
+                std = arr.std(axis=0, ddof=0) + 1e-6
+
+                # Окно наблюдения
+                normalized = (arr[-90:] - mean) / std
+
                 def prep_input(data, invert=False):
                     d = data.copy()
                     if invert:
@@ -389,10 +398,12 @@ class CustomD3QNStrategy4z(IStrategy):
                 last_window = dataframe[['open_z', 'high_z', 'low_z', 'close_z', 'volume_z']].iloc[-window:].values.copy().astype(np.float32)
             else:
                 raw_cols = ['open', 'high', 'low', 'close', 'volume']
-                df_slice = dataframe[raw_cols].iloc[-180:].copy()
-                df_slice['volume'] = np.log1p(df_slice['volume'])
-                mean, std = df_slice.mean().values, df_slice.std().values + 1e-6
-                last_window = ((df_slice.iloc[-window:].values - mean) / std).astype(np.float32)
+                arr = dataframe[raw_cols].iloc[-180:].values.astype(np.float32)
+                arr[:, 4] = np.log1p(arr[:, 4])
+
+                mean = arr.mean(axis=0)
+                std = arr.std(axis=0, ddof=0) + 1e-6
+                last_window = ((arr[-window:] - mean) / std).astype(np.float32)
             if should_invert:
                 last_window[:, :4] *= -1.0
                 last_window[:, [1, 2]] = last_window[:, [2, 1]]


### PR DESCRIPTION
The normalization process in `CustomD3QNStrategy4z.py` was a CPU bottleneck due to the use of Pandas within hot loops. Additionally, there was a mathematical discrepancy between training and inference because Pandas uses `ddof=1` by default for standard deviation, while the RL models were trained using NumPy's default `ddof=0`. 

This change migrates the normalization logic to NumPy, significantly reducing overhead and ensuring statistical consistency. Specific improvements include:
1. Fast NumPy array extraction from DataFrames.
2. Vectorized `mean` and `std` calculations with `ddof=0`.
3. Efficient broadcasting for Z-score normalization.
4. Numerical stability via `1e-6` epsilon.

---
*PR created automatically by Jules for task [9839551495977764774](https://jules.google.com/task/9839551495977764774) started by @FMProducer*