### PR TITLE
Alpha Decay Exit Implementation

### DIFF
--- a/third_party/rl-trading-binance/user_data/strategies/CustomD3QNStrategy4z.py
+++ b/third_party/rl-trading-binance/user_data/strategies/CustomD3QNStrategy4z.py
@@ -2060,8 +2060,14 @@ class CustomD3QNStrategy4z(IStrategy):
     def populate_exit_trend(self, dataframe: DataFrame, metadata: dict) -> DataFrame:
         """
         Логика выходов: 
-        Фильтр 3: Climax reversal (Vol peak + divergence).
+        1. Противоположный сигнал ансамбля (Alpha Decay).
+        2. Фильтр 3: Climax reversal (Vol peak + divergence).
         """
+        # Выход по противоположному сигналу ансамбля (переворот)
+        if 'enter_short' in dataframe.columns and 'enter_long' in dataframe.columns:
+            dataframe['exit_long'] = np.where(dataframe['enter_short'] == 1, 1, dataframe.get('exit_long', 0))
+            dataframe['exit_short'] = np.where(dataframe['enter_long'] == 1, 1, dataframe.get('exit_short', 0))
+
         if not self.vol_f3_enabled.value:
             return dataframe
 


### PR DESCRIPTION
Внедрена логика выхода по противоположному сигналу (Alpha Decay) в стратегию CustomD3QNStrategy4z. Теперь позиция закрывается, если ансамбль сигнализирует о развороте тренда (например, выход из лонга при сигнале в шорт), что математически обосновано испарением "альфы" текущего направления. Изменения внесены в метод `populate_exit_trend` с использованием векторизованных операций для сохранения производительности и поддержки существующих фильтров выхода.

---
*PR created automatically by Jules for task [7091853563987238520](https://jules.google.com/task/7091853563987238520) started by @FMProducer*