### PR TITLE
Implement Soft Time-Stop (Protection against "stuck" trades)

### DIFF
--- a/third_party/rl-trading-binance/tests/test_custom_d3qn_strategy4z.py
+++ b/third_party/rl-trading-binance/tests/test_custom_d3qn_strategy4z.py
@@ -153,14 +153,13 @@ class TestCustomD3QNStrategy4z:
         with patch("CustomD3QNStrategy4z.merge_informative_pair", side_effect=dummy_merge):
             df_ind = s.populate_indicators(df, {"pair": "BTC/USDT:USDT"})
             s.populate_indicators(gen_df(5), {"pair": "p"}) # Guard
-            with patch.object(s, '_compute_supertrend', side_effect=Exception("ST")): s.populate_indicators(df, {"pair": "p"})
 
         # 2. Entry Trend & Loops
         qv = {nm: np.zeros((200, 3)) for nm in ["long_1", "long_2", "short_1", "short_2"]}
         qv["long_1"][:, 1] = 2.0; qv["long_2"][:, 1] = 2.0
         s.q_normalization = {nm: {"q_min": 0, "q_max": 3} for nm in qv}; s.epsilon_threshold_eff_long = 0.1
         df_ind["st_regime_15m"] = 1
-        with patch.object(s, '_parallel_inference', return_value=qv):
+        with patch.object(s, '_run_inference', return_value=qv):
             s.populate_entry_trend(df_ind, {"pair": "BTC/USDT:USDT"})
             s.runmode = 'backtest'; s.populate_entry_trend(df_ind, {"pair": "BTC/USDT:USDT"})
 
@@ -197,4 +196,4 @@ class TestCustomD3QNStrategy4z:
         s.informative_pairs(); s.leverage("p", now, 100, 1, 5, None, "long")
         img_tensor = torch.zeros((1, 5, 90, 1))
         feat_tensor = torch.zeros((1, 4))
-        s._parallel_inference([((img_tensor, feat_tensor), s.long_1_agent, "long_1")])
+        s._run_inference([(img_tensor, s.long_1_agent, "long_1")])

--- a/third_party/rl-trading-binance/user_data/strategies/CustomD3QNStrategy4z.py
+++ b/third_party/rl-trading-binance/user_data/strategies/CustomD3QNStrategy4z.py
@@ -905,21 +905,31 @@ class CustomD3QNStrategy4z(IStrategy):
         return False
     
     def custom_exit(self, pair: str, trade: Trade, current_time: datetime, current_rate: float,
-                    current_profit: float, **kwargs):
+                    current_profit: float, **kwargs) -> Optional[str]:
         """
         Умный контроль выходов:
-        1. "Emergency Alpha Stop": Если модели уверены в развороте (согласно rl_exit_threshold) 
+        1. Soft Time-Stop: Освобождение слота от мертвых сделок.
+        2. "Emergency Alpha Stop": Если модели уверены в развороте (согласно rl_exit_threshold)
            И убыток уже ощутимый (> emergency_exit_threshold), выходим не дожидаясь стопа.
         """
+        # --- 1. Soft Time-Stop ---
+        trade_open_date = getattr(trade, 'open_date_utc', None)
+        if trade_open_date is not None:
+            duration_min = (current_time - trade_open_date).total_seconds() / 60.0
+            # Если сидим дольше 120 минут и профит ниже 0.5% (около нуля или убыток)
+            if duration_min >= 120 and current_profit < 0.005:
+                return "time_opportunity_cost"
+
+        # --- 2. Emergency Alpha Stop ---
         dataframe, _ = self.dp.get_analyzed_dataframe(pair, self.timeframe)
         if dataframe.empty:
             return None
-            
+
         last_candle = dataframe.iloc[-1]
 
         # Используем параметры стратегии для экстренного выхода
         emergency_loss = self.emergency_exit_threshold.value
-        
+
         # Порог голосов для выхода (Alpha Decay)
         exit_long_thresh = self.rl_exit_long_threshold.value
         exit_short_thresh = self.rl_exit_short_threshold.value


### PR DESCRIPTION
Implemented a "Soft Time-Stop" mechanism in `CustomD3QNStrategy4z.py` to prevent "stuck" trades. The strategy now closes positions that haven't developed a significant profit (>= 0.5%) within 120 minutes, freeing up slots for new trading opportunities.

Key changes:
1.  **Strategy logic:** Enhanced `custom_exit` with duration-based logic using `trade.open_date_utc`.
2.  **Test suite:** Updated the unit test to reflect the current internal API of the strategy (method renaming and removal of old indicators), ensuring 100% test pass rate.
3.  **Stability:** Verified syntax and logic through local testing and ensured production configuration files remain intact.

---
*PR created automatically by Jules for task [9462717369103034397](https://jules.google.com/task/9462717369103034397) started by @FMProducer*