### PR TITLE
Fix ValueError in PortfolioCalculator with negative thresholds

### DIFF
--- a/futures_portfolio/calculator.py
+++ b/futures_portfolio/calculator.py
@@ -70,11 +70,13 @@ class PortfolioCalculator:
         }
 
         # Проверяем, превышен ли порог хотя бы одной ногой
-        any_exceeded: bool = False
-        for key in ["BASE_LONG", "BASE_SHORT", "VIRTUAL"]:
-            if not math.isclose(shares[key], targets[key]["share"], abs_tol=threshold):
-                any_exceeded = True
-                break
+        any_exceeded: bool = threshold < 0.0
+
+        if not any_exceeded:
+            for key in ["BASE_LONG", "BASE_SHORT", "VIRTUAL"]:
+                if not math.isclose(shares[key], targets[key]["share"], abs_tol=threshold):
+                    any_exceeded = True
+                    break
 
         if not any_exceeded:
             return []


### PR DESCRIPTION
This PR fixes a critical bug where `math.isclose` would raise a `ValueError` if a negative threshold was passed to the `calculate_deviations` method in `PortfolioCalculator`. 

The orchestrator uses `threshold = -1.0` to force a full rebalance on startup. The fix short-circuits the check by setting `any_exceeded = True` immediately if the threshold is negative, bypassing the `math.isclose` calls.

Verified with a reproduction script and existing unit tests.

---
*PR created automatically by Jules for task [18253017427168098360](https://jules.google.com/task/18253017427168098360) started by @FMProducer*