### PR TITLE
Fix rounding logic and event loop blocking

### DIFF
--- a/futures_portfolio/executor.py
+++ b/futures_portfolio/executor.py
@@ -28,9 +28,9 @@ class PortfolioExecutor:
         if step_size <= 0:
             return qty
 
-        # log10 от 0.001 даст -3. Инвертируем знак для получения количества знаков после запятой.
         precision = max(0, int(round(-math.log10(step_size))))
-        return round(qty, precision)
+        # Strictly mathematically correct rounding for arbitrary steps (e.g., 0.05, 0.03)
+        return round(round(qty / step_size) * step_size, precision)
 
     async def execute_market_order(self, symbol: str, qty: float, side: str, step_size: float = 0.0, reduce_only: bool = False, position_side: str = "BOTH", min_notional: float = 6.0, price: float = 0.0) -> Dict:
         """
@@ -172,6 +172,10 @@ class PortfolioExecutor:
 
             # Добиваем остаток market-ордером
             if qty > 0:
+                # CRITICAL: Re-verify notional value for the remaining snippet
+                if (qty * mid_price) < min_notional:
+                    logger.warning(f"Fallback snippet too small ({qty * mid_price:.2f} < {min_notional}). Discarding remainder.")
+                    return {"status": "SUCCESS_PARTIAL", "filled_qty": filled_qty, "message": "Remainder dropped due to min_notional"}
                 market_result = await self.execute_market_order(
                     symbol=symbol,
                     qty=qty,

--- a/futures_portfolio/main.py
+++ b/futures_portfolio/main.py
@@ -19,6 +19,11 @@ from storage import safe_load_json as load_json, safe_save_json as save_json
 from pathlib import Path
 
 
+def sync_read_json(path: str) -> Dict:
+    with open(path, 'r', encoding='utf-8') as f:
+        return json.load(f)
+
+
 def emit_signal(signal_type: str, ticker: str) -> None:
     """Создает пустой файл-флаг для супервайзера."""
     sig_path = Path("signals") / f"{signal_type}_{ticker}.flag"
@@ -155,8 +160,8 @@ async def rebalance_loop(connector: BinanceConnector, config_path: str, state_fi
             try:
                 # Dynamic config reload
                 try:
-                    with open(config_path, 'r', encoding='utf-8') as f:
-                        current_config = json.load(f)
+                    # Unblock the Event Loop
+                    current_config = await asyncio.to_thread(sync_read_json, config_path)
                     portfolio_cfg = current_config["portfolios"][0]
                     targets = portfolio_cfg["targets"]
                     global_threshold = portfolio_cfg["rebalance_threshold"]


### PR DESCRIPTION
Applied two critical patches to the futures_portfolio module:
1.  **Executor Improvements**: Fixed the `round_quantity` method to use a mathematically correct formula for arbitrary `LOT_SIZE` steps (e.g., 0.05). Added a `min_notional` check in `execute_limit_with_fallback` to prevent small remainder snippets from triggering exchange errors during fallback.
2.  **Performance Optimization**: Prevented event loop blocking in `main.py` by offloading synchronous JSON config reading to a separate thread using `asyncio.to_thread`.

---
*PR created automatically by Jules for task [6358202636999919125](https://jules.google.com/task/6358202636999919125) started by @FMProducer*