### PR TITLE
Enforce SSOT for profit calculation in supervisor and analyzer

### DIFF
--- a/futures_portfolio/main.py
+++ b/futures_portfolio/main.py
@@ -680,7 +680,7 @@ async def emergency_stop(connector: BinanceConnector, config_path: str, state_fi
                 "timestamp": time.time(),
                 "state": state,
                 "paper_state": paper_state,
-                "final_profit": (paper_state.get("balance", 0) + state.get("virt_qty", 0) * paper_state.get("last_price", 0)) - initial_capital + state.get("siphoning_reserve", 0)
+                "final_profit": state.get("last_profit", 0.0)
             }
             archive_path = history_dir / f"archive_{base_ticker}_{int(time.time())}.json"
             await save_json(str(archive_path), archive_data)

--- a/futures_portfolio/supervisor.py
+++ b/futures_portfolio/supervisor.py
@@ -129,19 +129,19 @@ async def get_real_bot_stats(ticker: str, initial_capital: float, config: dict, 
     if not state or not paper_state:
         return {}
         
-    paper_balance = paper_state.get("balance", initial_capital)
-    last_price = paper_state.get("last_price", 0.0)
-    virt_qty = state.get("virt_qty", 0.0)
     siphoned = state.get("siphoning_reserve", 0.0)
     cycles = state.get("rebalance_cycles", 0)
     last_update = state.get("last_update", 0)
     
-    # Расчет TPV: Баланс кэша + Стоимость Виртуальной части
-    current_virt_value = virt_qty * last_price
-    current_tpv = paper_balance + current_virt_value
+    # Архитектурное исправление: Строгий SSOT.
+    # Супервайзер не должен вычислять TPV (иначе теряется PnL L/S ног).
+    # Читаем готовый расчет напрямую от main.py.
+    profit_usdt = state.get("last_profit", 0.0)
     
-    # Расчет профита: (Текущий TPV - Начальный) + SAFE
-    profit_usdt = (current_tpv - initial_capital) + siphoned
+    # Если бот уже уволен, читаем его зафиксированный финальный PnL
+    if "final_profit" in state and ticker not in running_info:
+        profit_usdt = state.get("final_profit", profit_usdt)
+
     profit_pct = (profit_usdt / initial_capital) * 100 if initial_capital > 0 else 0
     
     # Используем profit_probation если он есть

--- a/futures_portfolio/swarm_analyzer.py
+++ b/futures_portfolio/swarm_analyzer.py
@@ -22,31 +22,33 @@ def analyze_swarm():
 
     total_net_pnl = 0
     total_safe = 0
-    files = glob.glob("paper_state_*.json")
+    files = glob.glob("state_*.json")
     
     results = []
     
     for f in files:
         try:
             with open(f, 'r') as j:
-                data = json.load(j)
-                balance = data.get('balance', initial_per_bot)
+                state_data = json.load(j)
                 
                 # Извлекаем тикер
-                ticker_from_file = os.path.basename(f).replace('paper_state_', '').replace('.json', '')
-                ticker = data.get('base_ticker', ticker_from_file)
+                ticker_from_file = os.path.basename(f).replace('state_', '').replace('.json', '')
+                ticker = state_data.get('base_ticker', ticker_from_file)
                 
-                # Ищем соответствующий state_*.json для получения SAFE
-                safe_reserve = 0.0
-                state_file = f"state_{ticker}.json"
-                if os.path.exists(state_file):
-                    with open(state_file, 'r') as sj:
-                        state_data = json.load(sj)
-                        safe_reserve = state_data.get('siphoning_reserve', 0.0)
+                # Архитектурное исправление: Читаем готовый расчет напрямую от main.py.
+                total_ticker_pnl = state_data.get("last_profit", 0.0)
+                if "final_profit" in state_data:
+                    total_ticker_pnl = state_data.get("final_profit", total_ticker_pnl)
                 
-                # Расчет PnL: (Текущий баланс - Начальный) + То что ушло в SAFE
-                working_pnl = balance - initial_per_bot
-                total_ticker_pnl = working_pnl + safe_reserve
+                safe_reserve = state_data.get('siphoning_reserve', 0.0)
+
+                # Для отображения баланса ищем paper_state
+                balance = initial_per_bot
+                paper_state_file = f"paper_state_{ticker}.json"
+                if os.path.exists(paper_state_file):
+                    with open(paper_state_file, 'r') as p_j:
+                        p_data = json.load(p_j)
+                        balance = p_data.get('balance', initial_per_bot)
                 
                 total_net_pnl += total_ticker_pnl
                 total_safe += safe_reserve


### PR DESCRIPTION
This change addresses a critical architectural flaw where the supervisor and other reporting tools were manually (and incorrectly) recalculating portfolio profit, often omitting the unrealized PnL of active Long/Short positions. By enforcing a Single Source of Truth (SSOT), these components now retrieve the `last_profit` value directly from the core engine's state, which is pre-calculated with full PnL awareness.

Specifically:
1. `supervisor.py`: The `get_real_bot_stats` function now uses `state.get("last_profit")`. Redundant manual calculation variables were removed.
2. `main.py`: The `emergency_stop` function now archives `final_profit` using the `last_profit` from the state.
3. `swarm_analyzer.py`: Switched to scanning `state_*.json` files as the primary source, using `last_profit` and `final_profit` for consistent reporting.

---
*PR created automatically by Jules for task [14897573262970444274](https://jules.google.com/task/14897573262970444274) started by @FMProducer*