### PR TITLE
Implement Bot Efficiency Ranking in Swarm Supervisor

### DIFF
--- a/futures_portfolio/config.json
+++ b/futures_portfolio/config.json
@@ -7,6 +7,7 @@
   "min_notional_usdt": 6.1,
   "max_orders_per_second": 10,
   "max_bots": 20,
+  "min_cycles_for_rank": 10,
   "paper_mode_bots": 19,
   "probation_period_days": 0.02,
   "backtest_period_days": 0.125,

--- a/futures_portfolio/supervisor.py
+++ b/futures_portfolio/supervisor.py
@@ -154,6 +154,10 @@ async def get_real_bot_stats(ticker: str, initial_capital: float, config: dict, 
     # Проверка активности
     is_active = (time.time() - last_update) < 600 if last_update > 0 else False
     
+    # Efficiency calculation: Average profit per cycle, protected from division by zero
+    min_cycles = config.get("min_cycles_for_rank", 10)
+    efficiency = profit_usdt / max(cycles, min_cycles)
+
     # Прунинг: Только по абсолютному убытку (Overall PnL < 0)
     if profit_usdt < 0:
         # ЗАЩИТА НОВИЧКА: Не убиваем сразу после старта (даем время отбить комиссию)
@@ -186,6 +190,7 @@ async def get_real_bot_stats(ticker: str, initial_capital: float, config: dict, 
     return {
         "profit": profit_pct,
         "profit_usdt": profit_usdt,
+        "efficiency": efficiency,
         "safe": siphoned,
         "cycles": cycles,
         "is_active": is_active,
@@ -274,15 +279,16 @@ async def manage_swarm():
         if symbol not in perf_dict:
             perf_dict[symbol] = {
                 "profit": 0.0,
+                "efficiency": 0.0,
                 "is_real_data": False,
                 "trailing_stop_paper_timeout_end": 0.0
             }
 
-    # Сортировка: Только по текущему общему PnL (%)
+    # Сортировка: По эффективности (средний профит на цикл)
     def ranking_key(t):
         p = perf_dict[t]
-        # Rank by current total profit percentage (overall PnL)
-        return p.get('profit', 0.0)
+        # Rank by efficiency (USDT/Cycle)
+        return p.get('efficiency', 0.0)
 
     all_sorted = sorted(perf_dict.keys(), key=ranking_key, reverse=True)
 
@@ -329,7 +335,7 @@ async def manage_swarm():
             ready_pool.append(ticker)
 
     # Сортировка REAL пула (лучшие из ПРИБЫЛЬНЫХ и ГОТОВЫХ)
-    ready_pool.sort(key=lambda x: perf_dict[x]['profit'], reverse=True)
+    ready_pool.sort(key=lambda x: perf_dict[x]['efficiency'], reverse=True)
     target_real_bots = ready_pool[:max_real_slots]
     
     # ИТОГОВЫЙ СПИСОК (всего max_bots слотов)

--- a/futures_portfolio/swarm_analyzer.py
+++ b/futures_portfolio/swarm_analyzer.py
@@ -10,6 +10,7 @@ def analyze_swarm():
             # Берем initial_capital из первого портфеля (обычно 39000)
             initial_per_bot = config['portfolios'][0].get('initial_capital', 39000.0)
             max_bots = config.get('max_bots', 10)
+            min_cycles_for_rank = config.get('min_cycles_for_rank', 10)
             working_capital = initial_per_bot * max_bots
             active_tickers = config.get('tickers', [])
             live_swarm = config.get('live_swarm', [])
@@ -40,6 +41,9 @@ def analyze_swarm():
                 if "final_profit" in state_data:
                     total_ticker_pnl = state_data.get("final_profit", total_ticker_pnl)
                 
+                cycles = int(state_data.get('rebalance_cycles', 0))
+                efficiency = total_ticker_pnl / max(cycles, min_cycles_for_rank)
+
                 safe_reserve = state_data.get('siphoning_reserve', 0.0)
 
                 # Для отображения баланса ищем paper_state
@@ -58,6 +62,7 @@ def analyze_swarm():
                     "balance": balance,
                     "safe": safe_reserve,
                     "pnl": total_ticker_pnl,
+                    "eff": efficiency,
                     "mode": "REAL" if ticker in live_swarm else "PAPER"
                 })
         except Exception as e:
@@ -66,13 +71,13 @@ def analyze_swarm():
     # Сортировка по общему профиту
     results.sort(key=lambda x: x['pnl'], reverse=True)
     
-    print(f"\n{'Ticker':<15} | {'Balance':<10} | {'SAFE':<10} | {'Total PnL':<10} | {'Mode':<7} | {'Status':<10}")
-    print("-" * 85)
+    print(f"\n{'Ticker':<15} | {'Balance':<10} | {'SAFE':<10} | {'Total PnL':<10} | {'Eff':<10} | {'Mode':<7} | {'Status':<10}")
+    print("-" * 98)
     for r in results:
         status = "Active" if r['ticker'] in active_tickers else "Removed"
-        print(f"{r['ticker']:<15} | {r['balance']:<10.2f} | {r['safe']:<10.2f} | {r['pnl']:<10.2f} | {r['mode']:<7} | {status:<10}")
+        print(f"{r['ticker']:<15} | {r['balance']:<10.2f} | {r['safe']:<10.2f} | {r['pnl']:<10.2f} | {r['eff']:<10.2f} | {r['mode']:<7} | {status:<10}")
         
-    print("-" * 85)
+    print("-" * 98)
     print(f"Total Swarm Net Profit: {total_net_pnl:.2f} USDT (including SAFE)")
     print(f"Total SAFE Reserve:     {total_safe:.2f} USDT")
     print(f"Overall ROI: {(total_net_pnl / working_capital) * 100:.2f}% (Relative to {working_capital} USDT deposit)")


### PR DESCRIPTION
This PR implements a more robust bot ranking mechanism in the swarm supervisor based on 'efficiency' (average profit per rebalance cycle) rather than absolute profit.

Key Changes:
1. **Configuration**: Added `min_cycles_for_rank` (default 10) to `config.json` to normalize ranking for new bots and prevent division by zero.
2. **Supervisor Ranking**: 
    - Modified `get_real_bot_stats` to calculate `efficiency = profit_usdt / max(cycles, min_cycles)`.
    - Updated `manage_swarm` to sort both the general pool and the REAL champion pool by this efficiency metric.
3. **Analytics**: Updated `swarm_analyzer.py` to include a new `Eff` column, allowing users to visually monitor the USDT/Cycle performance of each bot in the swarm.

This change ensures that bots are promoted based on their consistent performance relative to their activity level, rather than just their total accumulated profit.

---
*PR created automatically by Jules for task [11918437420556877937](https://jules.google.com/task/11918437420556877937) started by @FMProducer*