### PR TITLE
Refactor to strict Cash Accounting and 1.0 USDT Dust Guard

### DIFF
--- a/futures_portfolio/calculator.py
+++ b/futures_portfolio/calculator.py
@@ -27,10 +27,12 @@ class PortfolioCalculator:
         self.virt_entry_price = Decimal(str(virt_entry_price))
         self.targets = targets or {}
 
-        # 1. Calculate TPV: Real Equity (Futures) + Virtual PnL
-        # Virtual PnL = (Current Price - Entry Price) * Qty
-        self.virt_pnl = (self.price - self.virt_entry_price) * self.virt_qty if self.virt_qty > 0 else Decimal('0')
-        self.tpv = self.real_equity + self.virt_pnl
+        # TPV = Свободный кэш + Стоимость виртуального актива
+        self.virt_value = self.virt_qty * self.price
+        self.tpv = self.real_equity + self.virt_value
+
+        # PnL для логов: (Текущая цена / Цена входа - 1) * Навеска
+        self.virt_pnl_val = (self.price - self.virt_entry_price) * self.virt_qty if self.virt_entry_price > 0 else Decimal('0')
 
         if self.tpv <= 0:
             self.tpv = Decimal('1e-9')
@@ -55,7 +57,7 @@ class PortfolioCalculator:
         # PnL contributions for transparency
         self.pnl_l = (l_qty * (self.price - Decimal(str(long_entry_price)))) if l_qty > 0 else Decimal('0')
         self.pnl_s = (s_qty * (Decimal(str(short_entry_price)) - self.price)) if s_qty > 0 else Decimal('0')
-        self.pnl_v = self.virt_pnl
+        self.pnl_v = self.virt_pnl_val
 
         # 3. Cash is what's left in the futures wallet that isn't tied up in L/S margin/PnL
         # Since TPV = real_equity + val_virt, and real_equity = val_l + val_s + cash
@@ -129,13 +131,18 @@ class PortfolioCalculator:
 
             if abs(diff_share) > 0:
                 # Log the trigger reason (will be captured by main.py)
-                logger.info(f"Trigger: {key} deviation {diff_share*100:+.2f}% targets {target_share*100}%")
+                logger.debug(f"Trigger: {key} deviation {diff_share*100:+.2f}% targets {target_share*100}%")
 
             if key == "VIRTUAL":
                 # For Virtual, diff_usdt is the amount to move to/from Cash
                 # Positive diff_share means surplus (sell), Negative means deficit (buy)
                 # We want: >0 is BUY, <0 is SELL for consistency with main.py
                 diff_usdt = -diff_share * self.tpv
+
+                # Value-based Dust Guard: 1.0 USDT
+                if abs(diff_usdt) < Decimal('1.0'):
+                    continue
+
                 actions.append({
                     "type": "VIRTUAL_ORDER",
                     "symbol": "VIRTUAL",

--- a/futures_portfolio/main.py
+++ b/futures_portfolio/main.py
@@ -652,8 +652,10 @@ async def rebalance_loop(connector: BinanceConnector, config_path: str, state_fi
                                 if res.get("type") == "VIRTUAL_ORDER":
                                     # Update virtual quantity based on the USDT diff
                                     diff_usdt_val = res.get("diff_usdt", 0.0)
-                                    diff_usdt = Decimal(str(diff_usdt_val))
+                                    trade_value = abs(diff_usdt_val)
+                                    if trade_value < 1.0: continue # Dust Guard 1.0 USDT
                                     
+                                    diff_usdt = Decimal(str(diff_usdt_val))
                                     dec_price = Decimal(str(price))
                                     old_v_qty = Decimal(str(virt_qty))
                                     old_v_entry = Decimal(str(state.get("virt_entry_price", price)))
@@ -668,26 +670,26 @@ async def rebalance_loop(connector: BinanceConnector, config_path: str, state_fi
                                             # Update entry price for VIRTUAL leg (WAP logic)
                                             new_v_entry = (old_v_qty * old_v_entry + diff_usdt) / new_v_qty
                                             state["virt_entry_price"] = float(new_v_entry)
+
+                                        paper_state["balance"] -= float(diff_usdt) # Strict Cash Accounting
+                                        logger.info(f"➕ VIRTUAL BUY: {float(diff_usdt):.2f} USDT")
                                     else: # SELL (Decreasing virtual position)
-                                        qty_to_sell = abs(diff_usdt) / dec_price
-                                        if qty_to_sell > old_v_qty: qty_to_sell = old_v_qty
+                                        qty_to_sell = trade_value / float(dec_price)
+                                        if Decimal(str(qty_to_sell)) > old_v_qty: qty_to_sell = float(old_v_qty)
 
-                                        # Realize PnL from selling virtual quantity
-                                        realized_pnl = qty_to_sell * (dec_price - old_v_entry)
-                                        paper_state["balance"] += float(realized_pnl)
-
-                                        new_v_qty = old_v_qty - qty_to_sell
-                                        if new_v_qty < Decimal('0.001'):
+                                        actual_sell_value = qty_to_sell * float(dec_price)
+                                        new_v_qty = old_v_qty - Decimal(str(qty_to_sell))
+                                        if (new_v_qty * dec_price) < Decimal('1.0'): # Value-based Dust Guard
                                             new_v_qty = Decimal('0')
                                             state["virt_entry_price"] = 0.0
-                                        else:
-                                            # Entry price stays the same for remaining quantity
-                                            pass
+
+                                        paper_state["balance"] += actual_sell_value # Strict Cash Accounting
+                                        logger.info(f"➖ VIRTUAL SELL: {actual_sell_value:.2f} USDT")
                                     
                                     virt_qty = float(new_v_qty)
                                     state["virt_qty"] = virt_qty
                                     
-                                    logger.info(f"🔄 Virtual Fixed: {float(diff_usdt):+.4f} USDT order. New Qty: {virt_qty:.6f}, New Entry: {state.get('virt_entry_price'):.6g}")
+                                    logger.info(f"🔄 Virtual Updated. New Qty: {virt_qty:.6f}, New Entry: {state.get('virt_entry_price'):.6g}")
                                     continue
 
                                 # Update execution results info


### PR DESCRIPTION
This PR refactors the trading bot to use a strict Cash Accounting model for the virtual leg in paper trading. The shadow balance (`paper_state["balance"]`) now reflects available cash, decreasing on buys and increasing on sells. The TPV calculation has been updated to use the current market value of the virtual position. Additionally, a 1.0 USDT value-based Dust Guard has been implemented to prevent small trades and clear out dust positions. Logging noise has been reduced by moving rebalance trigger messages to the DEBUG level.

---
*PR created automatically by Jules for task [6304264804508710897](https://jules.google.com/task/6304264804508710897) started by @FMProducer*