### PR TITLE
Fix TypeError in Binance AsyncClient

### DIFF
--- a/futures_portfolio/connector.py
+++ b/futures_portfolio/connector.py
@@ -64,9 +64,8 @@ class BinanceConnector:
         self.base_ticker = base_ticker
         self.api_key = api_key
         
-        # Настройка сессии: отключаем доверие к системному окружению (прокси)
+        # Для aiohttp (AsyncClient) параметр 'proxies' недопустим в kwargs.
         requests_params = {
-            'proxies': {'http': None, 'https': None},
             'timeout': 15
         }
         


### PR DESCRIPTION
This change fixes a crash when starting PM2 workers due to incompatible proxy arguments in the BinanceConnector. The proxies key was removed from the requests_params dictionary passed to AsyncClient because aiohttp does not support it.

---
*PR created automatically by Jules for task [10418460977972279743](https://jules.google.com/task/10418460977972279743) started by @FMProducer*