### PR TITLE
Lazy Initialization for BinanceConnector AsyncClient

### DIFF
--- a/futures_portfolio/connector.py
+++ b/futures_portfolio/connector.py
@@ -29,6 +29,11 @@ def retry_on_network_error(retries: int = 3, delay: float = 2.0):
     """Декоратор для повторных попыток при сетевых ошибках."""
     def decorator(func: Callable):
         async def wrapper(*args, **kwargs):
+            # Lazy initialization of the client strictly inside the active Event Loop
+            self_obj = args[0] if args else None
+            if self_obj and hasattr(self_obj, '_ensure_client'):
+                await self_obj._ensure_client()
+
             last_err = None
             for attempt in range(retries):
                 try:
@@ -63,21 +68,23 @@ class BinanceConnector:
         self.testnet = testnet
         self.base_ticker = base_ticker
         self.api_key = api_key
-        
-        # Для aiohttp (AsyncClient) параметр 'proxies' недопустим в kwargs.
-        requests_params = {
-            'timeout': 15
-        }
-        
-        # Initialize AsyncClient directly
-        if testnet:
-            self.client = AsyncClient(api_key, secret_key, testnet=True, requests_params=requests_params)
-        else:
-            self.client = AsyncClient(api_key, secret_key, testnet=False, requests_params=requests_params)
-            self.client.API_URL = 'https://api1.binance.com/api'
-            self.client.FUTURES_URL = 'https://fapi.binance.com/fapi'
-            
-        self.futures_client = self.client
+        self.secret_key = secret_key
+        self.client = None
+        self.futures_client = None
+
+    async def _ensure_client(self):
+        if self.client is None:
+            requests_params = {'timeout': 15}
+            self.client = AsyncClient(
+                self.api_key,
+                self.secret_key,
+                testnet=self.testnet,
+                requests_params=requests_params
+            )
+            if not self.testnet:
+                self.client.API_URL = 'https://api1.binance.com/api'
+                self.client.FUTURES_URL = 'https://fapi.binance.com/fapi'
+            self.futures_client = self.client
 
     @retry_on_network_error(retries=5, delay=3.0)
     async def get_positions(self) -> Dict[str, Dict]:

--- a/futures_portfolio/tests/test_connector.py
+++ b/futures_portfolio/tests/test_connector.py
@@ -6,7 +6,7 @@ from binance.exceptions import BinanceAPIException
 import requests.exceptions
 
 @pytest.fixture
-def connector():
+def connector_setup():
     with patch("futures_portfolio.connector.AsyncClient") as mock_client:
         # Mock the instance created by AsyncClient()
         mock_instance = mock_client.return_value
@@ -28,16 +28,17 @@ def connector():
         mock_instance.futures_cancel_order = AsyncMock()
 
         conn = BinanceConnector(api_key="test_key", secret_key="test_secret", testnet=True)
-        return conn
+        yield conn, mock_instance
 
 @pytest.mark.asyncio
-async def test_get_positions(connector):
+async def test_get_positions(connector_setup):
+    connector, mock_instance = connector_setup
     mock_positions = [
         {"symbol": "BTCUSDT", "positionAmt": "0.5", "entryPrice": "60000", "positionSide": "LONG"},
         {"symbol": "BTCUSDT", "positionAmt": "-0.2", "entryPrice": "61000", "positionSide": "SHORT"},
         {"symbol": "ETHUSDT", "positionAmt": "0", "entryPrice": "0", "positionSide": "BOTH"}
     ]
-    connector.futures_client.futures_position_information.return_value = mock_positions
+    mock_instance.futures_position_information.return_value = mock_positions
     positions = await connector.get_positions()
     assert "BTCUSDT_LONG" in positions
     assert positions["BTCUSDT_LONG"]["qty"] == 0.5
@@ -46,16 +47,18 @@ async def test_get_positions(connector):
     assert "ETHUSDT" not in positions
 
 @pytest.mark.asyncio
-async def test_get_futures_prices(connector):
+async def test_get_futures_prices(connector_setup):
+    connector, mock_instance = connector_setup
     mock_prices = [{"symbol": "BTCUSDT", "price": "60000"}]
-    connector.futures_client.futures_symbol_ticker.return_value = mock_prices
+    mock_instance.futures_symbol_ticker.return_value = mock_prices
     prices = await connector.get_futures_prices(["BTCUSDT"])
     assert prices["BTCUSDT"] == 60000.0
 
 @pytest.mark.asyncio
-async def test_get_futures_prices_none_tickers(connector):
+async def test_get_futures_prices_none_tickers(connector_setup):
+    connector, mock_instance = connector_setup
     mock_prices = [{"symbol": "BTCUSDT", "price": "60000"}]
-    connector.futures_client.futures_symbol_ticker.return_value = mock_prices
+    mock_instance.futures_symbol_ticker.return_value = mock_prices
     prices = await connector.get_futures_prices(None)
     assert "BTCUSDT" in prices
 
@@ -84,53 +87,61 @@ async def test_retry_decorator_exhausted():
     assert mock_func.call_count == 2
 
 @pytest.mark.asyncio
-async def test_get_margin_ratio(connector):
+async def test_get_margin_ratio(connector_setup):
+    connector, mock_instance = connector_setup
     mock_account = {"totalMarginBalance": "10000", "totalMaintMargin": "500", "availableBalance": "9500"}
-    connector.futures_client.futures_account.return_value = mock_account
+    mock_instance.futures_account.return_value = mock_account
     info = await connector.get_margin_ratio()
     assert info["margin_ratio"] == 20.0
 
 @pytest.mark.asyncio
-async def test_get_hedge_mode(connector):
-    connector.futures_client.futures_get_position_mode.return_value = {"dualSidePosition": True}
+async def test_get_hedge_mode(connector_setup):
+    connector, mock_instance = connector_setup
+    mock_instance.futures_get_position_mode.return_value = {"dualSidePosition": True}
     assert await connector.get_hedge_mode() is True
 
 @pytest.mark.asyncio
-async def test_get_free_balance(connector):
+async def test_get_free_balance(connector_setup):
+    connector, mock_instance = connector_setup
     mock_balances = [{"asset": "USDT", "balance": "1000"}]
-    connector.futures_client.futures_account_balance.return_value = mock_balances
+    mock_instance.futures_account_balance.return_value = mock_balances
     balance = await connector.get_free_balance()
     assert balance == 1000.0
 
 @pytest.mark.asyncio
-async def test_place_limit_order(connector):
-    connector.futures_client.futures_create_order.return_value = {"orderId": 123}
+async def test_place_limit_order(connector_setup):
+    connector, mock_instance = connector_setup
+    mock_instance.futures_create_order.return_value = {"orderId": 123}
     res = await connector.place_limit_order("BTCUSDT", "BUY", 0.1, 60000, position_side="LONG")
     assert res["orderId"] == 123
 
 @pytest.mark.asyncio
-async def test_get_spot_prices(connector):
+async def test_get_spot_prices(connector_setup):
+    connector, mock_instance = connector_setup
     mock_prices = [{"symbol": "BTCUSDT", "price": "60000"}]
-    connector.client.get_all_tickers.return_value = mock_prices
+    mock_instance.get_all_tickers.return_value = mock_prices
     prices = await connector.get_spot_prices(["BTCUSDT"])
     assert prices["BTCUSDT"] == 60000.0
 
 @pytest.mark.asyncio
-async def test_get_futures_klines(connector):
+async def test_get_futures_klines(connector_setup):
+    connector, mock_instance = connector_setup
     mock_klines = [["data"]]
-    connector.futures_client.futures_klines.return_value = mock_klines
+    mock_instance.futures_klines.return_value = mock_klines
     klines = await connector.get_futures_klines("BTCUSDT", "1m")
     assert klines == mock_klines
 
 @pytest.mark.asyncio
-async def test_cancel_order(connector):
-    connector.futures_client.futures_cancel_order.return_value = {"status": "CANCELED"}
+async def test_cancel_order(connector_setup):
+    connector, mock_instance = connector_setup
+    mock_instance.futures_cancel_order.return_value = {"status": "CANCELED"}
     res = await connector.cancel_order("BTCUSDT", 123)
     assert res["status"] == "CANCELED"
 
 @pytest.mark.asyncio
-async def test_place_limit_maker_order(connector):
-    connector.futures_client.futures_create_order.return_value = {"orderId": 456}
+async def test_place_limit_maker_order(connector_setup):
+    connector, mock_instance = connector_setup
+    mock_instance.futures_create_order.return_value = {"orderId": 456}
     res = await connector.place_limit_maker_order("BTCUSDT", "SELL", 0.1, 61000)
     assert res["orderId"] == 456
 


### PR DESCRIPTION
This change implements lazy initialization for the BinanceConnector's AsyncClient. By deferring the creation of the AsyncClient until it's actually needed within an active asyncio event loop, we avoid common 'RuntimeError: Timeout context manager should be used inside a task' issues that occur when a client is created in a synchronous constructor but used in an asynchronous context. 

The implementation details:
1. Updated `retry_on_network_error` to detect if it's decorating a method of a class with `_ensure_client` and await it.
2. Refactored `BinanceConnector.__init__` to only store credentials.
3. Added `BinanceConnector._ensure_client` to handle the actual instantiation and configuration of the `AsyncClient`.
4. Updated the test suite to use a yielding fixture that provides access to the internal mock instances, ensuring compatibility with the new lazy loading pattern.

---
*PR created automatically by Jules for task [1019801720128243293](https://jules.google.com/task/1019801720128243293) started by @FMProducer*