### PR TITLE
Implement Notional-backed Equity and Remove Price Fuse

### DIFF
--- a/futures_portfolio/calculator.py
+++ b/futures_portfolio/calculator.py
@@ -100,15 +100,15 @@ class PortfolioCalculator:
         self.share_short_raw = self.val_short_notional / self.tpv
         self.share_virt_raw = self.val_virt_notional / self.tpv
 
-        # 5. DISPLAY SHARES (EQUITY-BASED) for Heartbeat readability
+        # 5. DISPLAY SHARES (NOTIONAL-BACKED EQUITY) for Heartbeat readability
         l_lev = Decimal(str(self.targets.get("BASE_LONG", {}).get("leverage", 5)))
         s_lev = Decimal(str(self.targets.get("BASE_SHORT", {}).get("leverage", 5)))
         
-        self.l_margin_equity = (l_qty * Decimal(str(long_entry_price)) / l_lev) + mtm_pnl_l if l_qty > 0 else Decimal('0')
-        self.s_margin_equity = (s_qty * Decimal(str(short_entry_price)) / s_lev) + mtm_pnl_s if s_qty > 0 else Decimal('0')
+        self.l_margin_notional = self.val_long_notional / l_lev
+        self.s_margin_notional = self.val_short_notional / s_lev
         
-        self.display_share_long = (self.l_margin_equity / self.tpv * 100).quantize(Decimal('0.01'), rounding=ROUND_HALF_EVEN)
-        self.display_share_short = (self.s_margin_equity / self.tpv * 100).quantize(Decimal('0.01'), rounding=ROUND_HALF_EVEN)
+        self.display_share_long = (self.l_margin_notional / self.tpv * 100).quantize(Decimal('0.01'), rounding=ROUND_HALF_EVEN)
+        self.display_share_short = (self.s_margin_notional / self.tpv * 100).quantize(Decimal('0.01'), rounding=ROUND_HALF_EVEN)
         self.display_share_virt = (self.val_virt_notional / self.tpv * 100).quantize(Decimal('0.01'), rounding=ROUND_HALF_EVEN)
         self.display_share_cash = (Decimal('100.00') - self.display_share_long - self.display_share_short - self.display_share_virt)
 
@@ -122,10 +122,10 @@ class PortfolioCalculator:
             "share_short_pct": float(self.display_share_short),
             "share_virt_pct": float(self.display_share_virt),
             "share_cash_pct": float(self.display_share_cash),
-            "val_long": float(self.l_margin_equity),
-            "val_short": float(self.s_margin_equity),
+            "val_long": float(self.l_margin_notional),
+            "val_short": float(self.s_margin_notional),
             "val_virt": float(self.val_virt_notional),
-            "val_cash": float(self.tpv - (self.l_margin_equity + self.s_margin_equity + self.val_virt_notional)),
+            "val_cash": float(self.tpv - (self.l_margin_notional + self.s_margin_notional + self.val_virt_notional)),
             "tpv": float(self.tpv),
             "total_tpv": float(self.total_tpv),
             "pnl_l": float(self.pnl_l),
@@ -189,12 +189,12 @@ class PortfolioCalculator:
                 final_actions.append(act)
                 total_proceeds += abs(Decimal(str(act["diff_equity"])))
 
-        # Available cash = Current Cash (MTM based) + Proceeds from sells
+        # Available cash = Real Equity (Wallet Balance - VirtDebt) minus locked margin
         l_lev = Decimal(str(targets["BASE_LONG"].get("leverage", 5)))
         s_lev = Decimal(str(targets["BASE_SHORT"].get("leverage", 5)))
         l_margin = (self.val_long_notional / l_lev)
         s_margin = (self.val_short_notional / s_lev)
-        current_cash = self.tpv - (l_margin + s_margin + self.val_virt_notional)
+        current_cash = self.real_equity - (l_margin + s_margin)
         available_funds = current_cash + total_proceeds
         
         deficit_actions.sort(key=lambda x: 0 if x["key"] == "VIRTUAL" else 1)

--- a/futures_portfolio/main.py
+++ b/futures_portfolio/main.py
@@ -186,20 +186,13 @@ async def rebalance_loop(connector: BinanceConnector, config_path: str, state_fi
                     min_notional = portfolio_cfg.get("min_notional_usdt", 7.0)
                     valid_actions = [a for a in actions if abs(a.get("diff_usdt", 0)) >= min_notional]
                     
-                    # [SYNC] Price Fuse (Scaled by leverage)
-                    last_reb_price = state.get("last_rebalance_price", 0.0)
-                    fused_actions = []
-                    if last_reb_price == 0: fused_actions = valid_actions
-                    else:
-                        for action in valid_actions:
-                            lev = action.get("leverage", 1.0)
-                            trigger = (threshold / lev) * 1.2
-                            diff = action["diff_usdt"]
-                            side = "BUY" if (action["position_side"] == "LONG" and diff > 0) or (action["position_side"] == "SHORT" and diff < 0) else "SELL"
-                            
-                            if side == "BUY" and price <= last_reb_price * (1 - trigger): fused_actions.append(action)
-                            elif side == "SELL" and price >= last_reb_price * (1 + trigger): fused_actions.append(action)
-                            elif i % 20 == 0: logger.info(f"🛡️ FUSE: {side} blocked by price trigger {trigger*100:.2f}%")
+                    # -------------------------------------------------------------------------
+                    # NOTIONAL REBALANCE (No Price Fuse)
+                    # -------------------------------------------------------------------------
+                    fused_actions = valid_actions
+
+                    if state.get("last_rebalance_price", 0.0) == 0:
+                        logger.info(f"❄️ Cold Start: Allowing all actions to form portfolio baseline at {price:.6g}")
 
                     if fused_actions:
                         logger.info(f"Rebalance needed ({len(fused_actions)} actions). TPV: {tpv_total:.2f}")

--- a/futures_portfolio/tests/test_calculator.py
+++ b/futures_portfolio/tests/test_calculator.py
@@ -1,6 +1,6 @@
 import pytest
 from decimal import Decimal
-from futures_portfolio.calculator import PortfolioCalculator
+from futures_portfolio.calculator import PortfolioCalculator, PortfolioRuinError
 
 @pytest.fixture
 def targets():
@@ -31,13 +31,13 @@ def test_calculator_initialization(sample_params):
     assert float(calc.total_tpv) == pytest.approx(12000.0)
     
     # Notional Long = 0.5 * 60000 = 30000
-    # Val Long = Margin (30000/5=6000) + PnL (0) = 6000
+    # Val Long = Notional Margin (30000/5=6000) = 6000
     # Share Long = 6000 / 12000 = 50%
-    assert float(calc.share_long_pct) == 50.0
-    assert float(calc.share_short_pct) == 0.0
+    assert float(calc.display_share_long) == 50.0
+    assert float(calc.display_share_short) == 0.0
     # Notional Virt = 2000
     # Share Virt = 2000 / 12000 = 16.67%
-    assert float(calc.share_virt_pct) == pytest.approx(16.67, abs=0.1)
+    assert float(calc.display_share_virt) == pytest.approx(16.67, abs=0.1)
 
 def test_calculate_deviations(sample_params, targets):
     calc = PortfolioCalculator(**sample_params)
@@ -84,19 +84,18 @@ def test_price_change_impact(sample_params):
     # TPV = 10000 + 3000 + 2200 = 15200.
     calc = PortfolioCalculator(**params)
     assert float(calc.tpv) == pytest.approx(15200.0)
-    # val_long = (0.5 * 60000 / 5) + 3000 = 9000.
-    # Share Long = 9000 / 15200 * 100 = 59.21%
-    assert float(calc.share_long_pct) == pytest.approx(59.21, abs=0.1)
+    # val_long = (0.5 * 66000 / 5) = 6600.
+    # Share Long = 6600 / 15200 * 100 = 43.42%
+    assert float(calc.display_share_long) == pytest.approx(43.42, abs=0.1)
 
 def test_negative_tpv_protection():
-    calc = PortfolioCalculator(
-        positions={},
-        spot_price=60000.0,
-        real_equity=-1000.0,
-        virt_qty=0.01 # 600 USDT
-    )
-    # tpv = -1000 + 600 = -400 -> protected to 1e-9
-    assert float(calc.tpv) == pytest.approx(1e-9)
+    with pytest.raises(PortfolioRuinError):
+        calc = PortfolioCalculator(
+            positions={},
+            spot_price=60000.0,
+            real_equity=-1000.0,
+            virt_qty=0.01 # 600 USDT
+        )
 
 def test_ignore_limits_deviation(sample_params, targets):
     params = sample_params.copy()


### PR DESCRIPTION
Critical architectural fix for the Notional-doctrine in the trading core. 
Key changes:
1. calculator.py: Switched display_share_* and val_* to Notional-Backed Equity (notional / leverage).
2. calculator.py: Fixed current_cash calculation to use real_equity (Wallet Balance - VirtDebt) minus locked margins, ensuring unrealized PnL is not used as collateral for surplus-first logic.
3. main.py: Removed Anti-Churn Price Fuse (BLSH) logic to allow mandatory volume synchronization for delta-neutral strategies.
4. test_calculator.py: Updated tests to match the new notional logic and exception-based ruin protection.

---
*PR created automatically by Jules for task [4555653186036072709](https://jules.google.com/task/4555653186036072709) started by @FMProducer*