### PR TITLE
Sync data contract between trading core and aggregator

### DIFF
--- a/futures_portfolio/aggregator.py
+++ b/futures_portfolio/aggregator.py
@@ -124,7 +124,7 @@ class StatusAggregator:
                 continue
 
             tpv = state.get("tpv", state.get("initial_capital", 0.0))
-            profit = state.get("last_profit", 0.0)
+            profit = state.get("total_pnl", state.get("last_profit", 0.0))
             cycles = state.get("rebalance_cycles", 0)
             siphoned = state.get("siphoning_reserve", 0.0)
 

--- a/futures_portfolio/main.py
+++ b/futures_portfolio/main.py
@@ -183,7 +183,17 @@ async def rebalance_loop(connector: BinanceConnector, config_path: str, state_fi
                     paper_state["tpv"] = float(tpv_total)
                     paper_state["rebalance_cycles"] = cycles
                     paper_state["total_pnl"] = float(Decimal(str(paper_state["balance"])) - Decimal(str(initial_tpv)))
+                    paper_state["share_long_pct"] = float(calc_res['share_long_pct'])
+                    paper_state["share_short_pct"] = float(calc_res['share_short_pct'])
+                    paper_state["share_virt_pct"] = float(calc_res['share_virt_pct'])
                     paper_state_dirty = True
+                else:
+                    state["tpv"] = float(tpv_total)
+                    state["total_pnl"] = float(calc_res['total_pnl'])
+                    state["share_long_pct"] = float(calc_res['share_long_pct'])
+                    state["share_short_pct"] = float(calc_res['share_short_pct'])
+                    state["share_virt_pct"] = float(calc_res['share_virt_pct'])
+                    state_dirty = True
 
                 # Heartbeat (Every 5 cycles)
                 if i % 5 == 0:


### PR DESCRIPTION
This PR synchronizes the data contract between the trading core and the status aggregator. It ensures that all necessary metrics for status reporting (share percentages, TPV, and total PnL) are consistently saved to the state files in both paper and real modes. Additionally, it updates the aggregator to use `total_pnl` as the primary metric for profit reporting, improving the accuracy of status updates.

---
*PR created automatically by Jules for task [8341558505375050454](https://jules.google.com/task/8341558505375050454) started by @FMProducer*