### PR TITLE
Modernize Swarm Consistency and Authoritative Cleanup with Whitelist Guard

### DIFF
--- a/futures_portfolio/supervisor.py
+++ b/futures_portfolio/supervisor.py
@@ -82,26 +82,29 @@ async def stop_bot(ticker: str, is_paper: bool = False):
     except: pass
 
 async def enforce_swarm_consistency(connector: BinanceConnector, config: dict):
-    logger.info("🛡️ Enforcing Swarm Consistency: Checking for unauthorized positions.")
+    logger.info("🛡️ Enforcing Swarm Consistency: Checking for unauthorized positions (respecting whitelist).")
     
     live_swarm_tickers = set(config.get("live_swarm", []))
-    active_positions = await connector.get_positions() # Получаем все открытые позиции с биржи
+    real_whitelist = set(config.get("real_whitelist", []))
+    allowed_tickers = live_swarm_tickers.union(real_whitelist)
+
+    active_positions = await connector.get_positions() # Get all open positions from exchange
 
     to_close_tickers = set()
 
-    # Если live_swarm пуст, закрываем все позиции
-    if not live_swarm_tickers:
+    # If allowed_tickers is empty, close all positions
+    if not allowed_tickers:
         if active_positions:
-            logger.warning("⚠️ live_swarm is empty. All open positions on exchange will be closed!")
+            logger.warning("⚠️ live_swarm and real_whitelist are empty. All open positions on exchange will be closed!")
             for pos_key in active_positions.keys():
                 ticker = pos_key.split('_')[0]
                 to_close_tickers.add(ticker)
     else:
-        # Если live_swarm не пуст, закрываем позиции по тикерам, которых нет в live_swarm
+        # If allowed_tickers is not empty, close positions for tickers not in allowed_tickers
         for pos_key in active_positions.keys():
             ticker = pos_key.split('_')[0]
-            if ticker not in live_swarm_tickers:
-                logger.warning(f"⚠️ Unauthorized position found for {ticker} (not in live_swarm). It will be closed!")
+            if ticker not in allowed_tickers:
+                logger.warning(f"⚠️ Unauthorized position found for {ticker} (not in live_swarm or real_whitelist). It will be closed!")
                 to_close_tickers.add(ticker)
 
     for ticker in to_close_tickers:
@@ -565,16 +568,18 @@ async def manage_swarm():
     max_real_slots = max(0, config.get("max_bots", 10) - config.get("paper_mode_bots", 9))
     target_real_bots = ready_pool[:max_real_slots]
     # -------------------------------------------------------------------------
-    # 3.5. [Authoritative Cleanup] Закрываем позиции на бирже для тех, кто не в live_swarm,  
-    # даже если PM2 процесс уже не найден (застрявшие позиции).
+    # 3.5. [Authoritative Cleanup] Close exchange positions for those not in live_swarm/whitelist,
+    # even if PM2 process is missing (stray positions).
+    real_whitelist = config.get("real_whitelist", [])
     active_positions = await connector.get_positions()
+    allowed_cleanup_tickers = set(target_real_bots).union(set(real_whitelist))
     for pos_key in active_positions.keys():
-        # pos_key имеет вид "SYMBOL_SIDE"
+        # pos_key is like "SYMBOL_SIDE"
         ticker = pos_key.split('_')[0]
-        if ticker not in target_real_bots:
+        if ticker not in allowed_cleanup_tickers:
             qty = active_positions[pos_key].get("qty", 0.0)
             if float(qty) != 0:
-                logger.warning(f"🧹 Authoritative Cleanup: Found stray position for {ticker}. Closing it!")
+                logger.warning(f"🧹 Authoritative Cleanup: Found stray position for {ticker} (not in live_swarm or whitelist). Closing it!")
                 cmd_stop = f'"{sys.executable}" "{BASE_PATH / "main.py"}" --config config.json --ticker {ticker} --stop --real'
                 await (await asyncio.create_subprocess_shell(cmd_stop)).wait()
 
@@ -585,6 +590,7 @@ async def manage_swarm():
     active_running_keys = set(running_bots.keys())
 
     # Сначала гасим тех, кто вылетел
+    real_whitelist = config.get("real_whitelist", [])
     for key, info in list(running_bots.items()):
         ticker = key.split("_")[1]
 
@@ -594,6 +600,10 @@ async def manage_swarm():
             active_running_keys.discard(key)
 
         if key.startswith("r_") and ticker not in target_real_bots:
+            if ticker in real_whitelist:
+                logger.info(f"🛡️ Whitelist Guard: {ticker} is not in target_real_bots but is explicitly whitelisted. Skipping termination.")
+                continue
+
             logger.info(f"🛑 Stopping Combat REAL process: {ticker} (Rolling back to pure paper tracking)")
             await stop_bot(ticker, is_paper=False)
             active_running_keys.discard(key)

--- a/futures_portfolio/tests/test_supervisor_rotation_whitelist.py
+++ b/futures_portfolio/tests/test_supervisor_rotation_whitelist.py
@@ -1,0 +1,61 @@
+
+import pytest
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+from futures_portfolio.supervisor import manage_swarm
+
+@pytest.mark.asyncio
+async def test_manage_swarm_respects_whitelist_during_rotation():
+    # Setup mock config
+    config = {
+        "api_key": "fake",
+        "secret_key": "fake",
+        "testnet": True,
+        "live_swarm": ["BTCUSDT"],
+        "real_whitelist": ["ETHUSDT"],
+        "tickers": ["BTCUSDT", "ETHUSDT"],
+        "max_bots": 10,
+        "paper_mode_bots": 8, # max_real_slots = 10 - 8 = 2
+        "min_cycles_for_rank": 10
+    }
+
+    # Mock dependencies
+    with patch("futures_portfolio.supervisor.safe_load_json", AsyncMock(return_value=config)), \
+         patch("futures_portfolio.supervisor.safe_save_json", AsyncMock()), \
+         patch("futures_portfolio.supervisor.BinanceConnector") as MockConnector, \
+         patch("futures_portfolio.supervisor.run_scanner", AsyncMock(return_value=[{"symbol": "BTCUSDT", "score": 100}])), \
+         patch("futures_portfolio.supervisor.get_running_bots_info", AsyncMock(return_value={
+             "r_BTCUSDT": {"name": "real-btc", "paper": False},
+             "r_ETHUSDT": {"name": "real-eth", "paper": False}
+         })), \
+         patch("futures_portfolio.supervisor.get_bot_efficiency", AsyncMock(return_value={"profit": 10.0, "cycles": 20})), \
+         patch("futures_portfolio.supervisor.stop_bot", AsyncMock()) as mock_stop_bot, \
+         patch("futures_portfolio.supervisor.start_bot", AsyncMock()), \
+         patch("asyncio.create_subprocess_shell", AsyncMock()) as mock_shell, \
+         patch("futures_portfolio.supervisor.enforce_swarm_consistency", AsyncMock()):
+
+        mock_connector = MockConnector.return_value
+        mock_connector.verify_connection = AsyncMock()
+        mock_connector.get_positions = AsyncMock(return_value={})
+
+        # We want to see if ETHUSDT is stopped.
+        # target_real_bots will likely only include BTCUSDT (if it's the top scorer)
+        # ETHUSDT is in running_bots but might not be in target_real_bots
+
+        await manage_swarm()
+
+        # Check if stop_bot was called for ETHUSDT
+        # In our case, ETHUSDT IS in real_whitelist, so it should NOT be stopped.
+
+        stop_bot_calls = [call.args[0] for call in mock_stop_bot.call_args_list if not call.args[1]] # is_paper=False
+        assert "ETHUSDT" not in stop_bot_calls
+
+        # Also check Authoritative Cleanup
+        # If we mock positions to include ETHUSDT
+        mock_connector.get_positions = AsyncMock(return_value={"ETHUSDT_LONG": {"qty": 1.0}})
+        await manage_swarm()
+
+        # Authoritative cleanup uses create_subprocess_shell with --stop
+        shell_calls = [call.args[0] for call in mock_shell.call_args_list]
+        assert not any("--ticker ETHUSDT" in c and "--stop" in c for c in shell_calls)

--- a/futures_portfolio/tests/test_supervisor_whitelist.py
+++ b/futures_portfolio/tests/test_supervisor_whitelist.py
@@ -1,0 +1,55 @@
+
+import pytest
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+from futures_portfolio.supervisor import enforce_swarm_consistency
+
+@pytest.mark.asyncio
+async def test_enforce_swarm_consistency_respects_whitelist():
+    # Setup mock connector
+    connector = AsyncMock()
+    connector.get_positions.return_value = {
+        "BTCUSDT_LONG": {"qty": 1.0},
+        "ETHUSDT_SHORT": {"qty": -2.0},
+        "SOLUSDT_LONG": {"qty": 5.0}
+    }
+
+    # Setup config: BTC in live_swarm, ETH in real_whitelist, SOL in neither
+    config = {
+        "live_swarm": ["BTCUSDT"],
+        "real_whitelist": ["ETHUSDT"]
+    }
+
+    # We want to check if it tries to close SOLUSDT but NOT BTCUSDT or ETHUSDT
+    with patch("asyncio.create_subprocess_shell", new_callable=AsyncMock) as mock_shell:
+        mock_process = AsyncMock()
+        mock_shell.return_value.wait = AsyncMock(return_value=0)
+        mock_shell.return_value = mock_process
+
+        await enforce_swarm_consistency(connector, config)
+
+        # Check calls to create_subprocess_shell
+        # It should be called for SOLUSDT
+        calls = [call.args[0] for call in mock_shell.call_args_list]
+
+        assert any("--ticker SOLUSDT" in c for c in calls)
+        assert not any("--ticker BTCUSDT" in c for c in calls)
+        assert not any("--ticker ETHUSDT" in c for c in calls)
+
+@pytest.mark.asyncio
+async def test_enforce_swarm_consistency_all_allowed():
+    connector = AsyncMock()
+    connector.get_positions.return_value = {
+        "BTCUSDT_LONG": {"qty": 1.0},
+        "ETHUSDT_SHORT": {"qty": -2.0}
+    }
+
+    config = {
+        "live_swarm": ["BTCUSDT"],
+        "real_whitelist": ["ETHUSDT"]
+    }
+
+    with patch("asyncio.create_subprocess_shell", new_callable=AsyncMock) as mock_shell:
+        await enforce_swarm_consistency(connector, config)
+
+        assert mock_shell.call_count == 0


### PR DESCRIPTION
This change updates `supervisor.py` to respect a `real_whitelist` in both `enforce_swarm_consistency` and `manage_swarm`. Whitelisted tickers are now protected from being stopped or having their exchange positions closed during automated cleanup and rotation cycles. Comments in the modified sections have also been updated to English for consistency.

---
*PR created automatically by Jules for task [7381389730327713720](https://jules.google.com/task/7381389730327713720) started by @FMProducer*