### PR TITLE
Implement Capital Continuity Doctrine in supervisor.py

### DIFF
--- a/futures_portfolio/supervisor.py
+++ b/futures_portfolio/supervisor.py
@@ -154,89 +154,70 @@ async def enforce_swarm_consistency(connector: BinanceConnector, config: dict) -
 
     return to_heal_tickers
 
-async def reset_real_state(ticker: str, config: dict):
-    """Архивирует текущее состояние реального бота и сбрасывает его перед новым запуском."""
-    base_state_path = BASE_PATH / f"real_state_{ticker}.json"
-    shadow_state_path = BASE_PATH / f"shadow_state_{ticker}.json"
+async def reset_bot_state_files(ticker: str, is_paper: bool, config: dict) -> None:
+    """
+    Сбрасывает файлы состояния к чистым начальным значениям, используя
+    динамическое ребазирование капитала для предотвращения инфляции баланса.
+    """
+    portfolio_cfg = config.get("portfolios", [{}])[0]
+    
+    if is_paper:
+        config_capital = portfolio_cfg.get("paper_initial_capital", portfolio_cfg.get("initial_capital", 115.0))
+        base_state_file = f"paper_state_{ticker}.json"
+        shadow_state_file = f"paper_shadow_{ticker}.json"
+    else:
+        config_capital = portfolio_cfg.get("initial_capital", 80.0)
+        base_state_file = f"real_state_{ticker}.json"
+        shadow_state_file = f"shadow_state_{ticker}.json"
+
+    base_state_path = BASE_PATH / base_state_file
+    shadow_state_path = BASE_PATH / shadow_state_file
     history_dir = BASE_PATH / "history"
     history_dir.mkdir(exist_ok=True)
+
+    old_state = await safe_load_json(str(base_state_path), {})
     
-    # Архивируем, если файлы существуют
+    # Динамическое ребазирование: сохраняем накопленный или урезанный стопом капитал
+    final_capital = old_state.get("last_tpv", config_capital) if old_state else config_capital
+
+    if old_state and (old_state.get("trailing_stop_triggered") or old_state.get("trailing_stop_violation_start", 0.0) > 0.0):
+        logger.warning(f"📉 Обнаружен Trailing Stop для {ticker}. Капитал ребазирован: {config_capital} -> {final_capital}")
+
+    # Архивируем старые файлы
     for path in [base_state_path, shadow_state_path]:
         if path.exists():
             archive_path = history_dir / f"archive_{ticker}_{int(time.time())}_{path.name}"
-            shutil.copy(path, archive_path)
-            logger.info(f"💾 Archived state for {ticker}: {path.name} -> {archive_path.name}")
-            os.remove(path)
-            logger.info(f"🗑️ Deleted stale state file: {path.name}")
+            try:
+                shutil.copy(path, archive_path)
+                logger.info(f"💾 Archived {'paper ' if is_paper else ''}state for {ticker}: {path.name} -> {archive_path.name}")
+                os.remove(path)
+                logger.info(f"🗑️ Deleted stale state file: {path.name}")
+            except Exception as e:
+                logger.error(f"Failed to archive {path}: {e}")
 
-    # Создаем базовые пустые файлы для чистого старта
-    portfolio_cfg = config.get("portfolios", [{}])[0]
-    initial_capital = portfolio_cfg.get("initial_capital", 100.0)
-    
-    await safe_save_json(str(base_state_path), {
+    new_state = {
         "virt_qty": 0.0,
         "base_ticker": ticker,
         "siphoning_reserve": 0.0,
-        "balance": initial_capital,
-        "initial_tpv": 0.0,
-        "reference_tpv": 0.0,
-        "tpv_ath": 0.0,
-        "rebalance_cycles": 0,
-        "last_rebalance_price": 0.0,
-        "started_at": time.time()
-    })
-    
-    await safe_save_json(str(shadow_state_path), {
-        "balance": initial_capital,
-        "positions": {f"{ticker}_LONG": 0.0, f"{ticker}_SHORT": 0.0},
-        "last_price": 0.0,
-        "base_ticker": ticker,
-        "long_entry_price": 0.0,
-        "short_entry_price": 0.0,
-        "long_liquidation_price": 0.0,
-        "short_liquidation_price": 0.0
-    })
-    logger.info(f"✨ Reset real state files for {ticker} to clean initial values.")
-
-async def reset_paper_state(ticker: str, config: dict):
-    """Архивирует текущее состояние paper-бота и сбрасывает его перед новым запуском."""
-    base_state_path = BASE_PATH / f"paper_state_{ticker}.json"
-    shadow_state_path = BASE_PATH / f"paper_shadow_{ticker}.json"
-    history_dir = BASE_PATH / "history"
-    history_dir.mkdir(exist_ok=True)
-    
-    # Архивируем, если файлы существуют
-    for path in [base_state_path, shadow_state_path]:
-        if path.exists():
-            archive_path = history_dir / f"archive_{ticker}_{int(time.time())}_{path.name}"
-            shutil.copy(path, archive_path)
-            logger.info(f"💾 Archived paper state for {ticker}: {path.name} -> {archive_path.name}")
-            os.remove(path)
-            logger.info(f"🗑️ Deleted stale paper state file: {path.name}")
-    
-    # Создаем чистые файлы для нового старта
-    portfolio_cfg = config.get("portfolios", [{}])[0]
-    initial_capital = portfolio_cfg.get("paper_initial_capital", portfolio_cfg.get("initial_capital", 115.0))
-    
-    await safe_save_json(str(base_state_path), {
-        "virt_qty": 0.0,
-        "base_ticker": ticker,
-        "siphoning_reserve": 0.0,
-        "balance": initial_capital,
-        "initial_tpv": 0.0,
-        "reference_tpv": 0.0,
-        "tpv_ath": 0.0,
+        "balance": final_capital,
+        "initial_tpv": final_capital,
+        "reference_tpv": final_capital,
+        "tpv_ath": final_capital,
         "trailing_stop_violation_start": 0.0,
         "trailing_stop_paper_timeout_end": 0.0,
         "trailing_stop_triggered": False,
         "rebalance_cycles": 0,
         "last_rebalance_price": 0.0,
-        "started_at": time.time()
-    })
+        "started_at": time.time(),
+        "virt_debt": 0.0,
+        "last_tpv": final_capital,
+        "last_profit": 0.0,
+        "total_pnl_pct": 0.0,
+        "last_update": time.time()
+    }
     
-    await safe_save_json(str(shadow_state_path), {
-        "balance": initial_capital,
+    new_shadow_state = {
+        "balance": final_capital,
         "positions": {f"{ticker}_LONG": 0.0, f"{ticker}_SHORT": 0.0},
         "last_price": 0.0,
         "base_ticker": ticker,
@@ -244,8 +225,11 @@ async def reset_paper_state(ticker: str, config: dict):
         "short_entry_price": 0.0,
         "long_liquidation_price": 0.0,
         "short_liquidation_price": 0.0
-    })
-    logger.info(f"✨ Reset paper state files for {ticker} to clean initial values (capital: {initial_capital}).")
+    }
+
+    await safe_save_json(str(base_state_path), new_state)
+    await safe_save_json(str(shadow_state_path), new_shadow_state)
+    logger.info(f"✨ Reset {'paper' if is_paper else 'real'} state files for {ticker} to clean initial values (capital: {final_capital}).")
 
 async def start_bot(ticker: str, is_paper: bool = True, config: dict = None):
     prefix = "paper" if is_paper else "real"
@@ -255,11 +239,11 @@ async def start_bot(ticker: str, is_paper: bool = True, config: dict = None):
     # Перед запуском: сбрасываем state для paper (чистый старт), для real — только если файлов нет
     if config:
         if is_paper:
-            await reset_paper_state(ticker, config)  # Paper always starts fresh
+            await reset_bot_state_files(ticker, is_paper=True, config=config)  # Paper always starts fresh
         else:
             state_path = BASE_PATH / f"real_state_{ticker}.json"
             if not state_path.exists():
-                await reset_real_state(ticker, config)
+                await reset_bot_state_files(ticker, is_paper=False, config=config)
 
     cmd = f'pm2 start main.py --name "{proc_name}" --cwd "{BASE_PATH}" --update-env --interpreter "{sys.executable}" --instances 1 -- --config config.json --ticker {ticker} {mode_flag}'
     await (await asyncio.create_subprocess_shell(cmd)).wait()

--- a/futures_portfolio/tests/test_supervisor.py
+++ b/futures_portfolio/tests/test_supervisor.py
@@ -3,7 +3,7 @@ import math
 import json
 from unittest.mock import MagicMock, AsyncMock, patch, mock_open
 import supervisor
-from supervisor import calculate_bot_score, _calc_rotation_score, selective_merge_incubator, get_bot_efficiency, reset_real_state, reset_paper_state, enforce_swarm_consistency, _ensure_real_bots_alive, manage_swarm
+from supervisor import calculate_bot_score, _calc_rotation_score, selective_merge_incubator, get_bot_efficiency, reset_bot_state_files, enforce_swarm_consistency, _ensure_real_bots_alive, manage_swarm
 
 def test_calculate_bot_score():
     # is_in_drawdown=True -> INF
@@ -103,14 +103,15 @@ async def test_get_bot_efficiency():
         assert res["trailing_stop_paper_timeout_end"] == 123456789.0
 
 @pytest.mark.asyncio
-async def test_reset_real_state():
+async def test_reset_bot_state_files_real():
     config = {"portfolios": [{"initial_capital": 200.0}]}
     ticker = "BTCUSDT"
     with patch("supervisor.shutil.copy") as mock_copy, \
          patch("supervisor.os.remove") as mock_remove, \
          patch("supervisor.Path.exists", return_value=True), \
+         patch("supervisor.safe_load_json", AsyncMock(return_value={})), \
          patch("supervisor.safe_save_json", AsyncMock()) as mock_save:
-        await reset_real_state(ticker, config)
+        await reset_bot_state_files(ticker, is_paper=False, config=config)
         assert mock_copy.call_count == 2
         assert mock_remove.call_count == 2
         assert mock_save.call_count == 2
@@ -120,14 +121,15 @@ async def test_reset_real_state():
         assert args[1]["base_ticker"] == ticker
 
 @pytest.mark.asyncio
-async def test_reset_paper_state():
+async def test_reset_bot_state_files_paper():
     config = {"portfolios": [{"paper_initial_capital": 150.0}]}
     ticker = "BTCUSDT"
     with patch("supervisor.shutil.copy") as mock_copy, \
          patch("supervisor.os.remove") as mock_remove, \
          patch("supervisor.Path.exists", return_value=True), \
+         patch("supervisor.safe_load_json", AsyncMock(return_value={})), \
          patch("supervisor.safe_save_json", AsyncMock()) as mock_save:
-        await reset_paper_state(ticker, config)
+        await reset_bot_state_files(ticker, is_paper=True, config=config)
         assert mock_copy.call_count == 2
         assert mock_remove.call_count == 2
         assert mock_save.call_count == 2
@@ -244,7 +246,7 @@ async def test_stop_bot():
 async def test_start_bot():
     config = {"portfolios": [{"initial_capital": 100}]}
     with patch("supervisor.asyncio.create_subprocess_shell", AsyncMock(return_value=AsyncMock())) as mock_shell, \
-         patch("supervisor.reset_paper_state", AsyncMock()) as mock_reset:
+         patch("supervisor.reset_bot_state_files", AsyncMock()) as mock_reset:
         await supervisor.start_bot("BTCUSDT", is_paper=True, config=config)
         assert mock_reset.called
         assert "pm2 start main.py" in mock_shell.call_args[0][0]


### PR DESCRIPTION
This patch implements the 'Capital Continuity Doctrine' in `supervisor.py`. The supervisor now extracts `last_tpv` from a closing bot's state file and uses it as the starting balance for the next incubator or real slot. This prevents balance inflation and ensures that performance metrics correctly reflect the bot's history across resets. The change also refactors the code to use a unified `reset_bot_state_files` function, improving maintainability while strictly adhering to the 'Pure Isolation' doctrine by keeping Paper and Real states separated.

---
*PR created automatically by Jules for task [9684662871274297703](https://jules.google.com/task/9684662871274297703) started by @FMProducer*