### PR TITLE
Fix Bot Rotation Bug After Trailing Stop

### DIFF
--- a/futures_portfolio/main.py
+++ b/futures_portfolio/main.py
@@ -51,10 +51,9 @@ async def _update_final_metrics_for_exit(state: dict, state_file_path: str, tota
             "total_pnl_pct": safe_calc_res.get("total_pnl_pct", 0.0),
             "last_update": time.time(),
             "rebalance_cycles": cycles,
-            # Очистка триггеров скользящего стопа для предотвращения повторного ложного срабатывания
+            # Очистка триггеров скользящего стопа (но сохраняем сам факт срабатывания для супервайзера)
             "trailing_stop_violation_start": 0.0,
-            "trailing_stop_paper_timeout_end": 0.0,
-            "trailing_stop_triggered": False
+            "trailing_stop_paper_timeout_end": 0.0
         })
 
         await save_json(state_file_path, state)
@@ -957,30 +956,9 @@ async def rebalance_loop(connector: BinanceConnector, config_path: str, state_fi
                                     logger.info(f"Sent STOP signal. Total Equity {tpv_total:.2f} < Global Initial {global_initial:.2f}. Ticker blacklisted.")
                                 else:
                                     # Trailing stop triggered with PROFIT
-                                    # Add to toxic_blacklist directly (not just exit flag)
+                                    # Delegate toxic_blacklist logic entirely to supervisor via IPC signal
                                     emit_signal("exit", base_ticker)
-                                    # Also write to toxic_blacklist in config for cooldown
-                                    try:
-                                        import json as _json
-                                        cfg_path = Path(config_path)
-                                        if cfg_path.exists():
-                                            cfg_data = _json.loads(cfg_path.read_text())
-                                            toxic = cfg_data.get("toxic_blacklist", {})
-                                            cooldown_days = cfg_data.get("toxic_cooldown_days", 0.02)
-                                            expiry = time.time() + cooldown_days * 86400
-                                            toxic[base_ticker] = expiry
-                                            cfg_data["toxic_blacklist"] = toxic
-                                            # Remove from live_swarm
-                                            live_swarm = cfg_data.get("live_swarm", [])
-                                            if base_ticker in live_swarm:
-                                                live_swarm.remove(base_ticker)
-                                                cfg_data["live_swarm"] = live_swarm
-                                                logger.info(f"❌ {base_ticker} removed from live_swarm")
-                                            cfg_path.write_text(_json.dumps(cfg_data, indent=2, ensure_ascii=False))
-                                            logger.info(f"✅ {base_ticker} added to toxic_blacklist until {time.ctime(expiry)} ({cooldown_days} days)")
-                                    except Exception as e:
-                                        logger.error(f"Failed to add {base_ticker} to toxic_blacklist: {e}")
-                                    logger.info(f"Sent EXIT signal (with toxic). Total Equity {tpv_total:.2f} >= Global Initial {global_initial:.2f}.")
+                                    logger.info(f"Sent EXIT signal. Total Equity {tpv_total:.2f} >= Global Initial {global_initial:.2f}.")
 
                                 logger.info("Positions closed and state sanitized for supervisor. Bot stopping.")
                                 break

--- a/futures_portfolio/supervisor.py
+++ b/futures_portfolio/supervisor.py
@@ -121,6 +121,12 @@ async def enforce_swarm_consistency(connector: BinanceConnector, config: dict) -
 
                 # Инвариант легитимности: у бота есть история или открытый виртуальный объем
                 if state_data.get("rebalance_cycles", 0) > 0 or abs(state_data.get("virt_qty", 0.0)) > 0:
+                    # Защита от воскрешения ботов, остановленных по Trailing Stop
+                    if state_data.get("trailing_stop_triggered", False):
+                        logger.warning(f"⚠️ HEAL REJECTED: {ticker} was stopped by Trailing Stop. Scheduling position liquidation.")
+                        to_close_tickers.add(ticker)
+                        continue
+
                     logger.warning(f"🚨 HEAL TRIGGERED: Active position for {ticker} detected on exchange, but PM2 process is dead. Real state file is valid. Initiating recovery...")
                     to_heal_tickers.add(ticker)
                     continue
@@ -460,24 +466,19 @@ async def manage_swarm():
     cooldown_sec = cooldown_days * 86400
 
     if signals_dir.exists():
-        # Собираем тикеры с stop-сигналом (отрицательный PnL → toxic)
-        for flag_file in signals_dir.glob("stop_*.flag"):
-            ticker = flag_file.stem[5:]  # убираем префикс "stop_"
-            expiry = now_ts + cooldown_sec
-            toxic_blacklist[ticker] = expiry
-            logger.info(f"🚫 STOP signal received for {ticker}. Blacklisted until {time.ctime(expiry)}")
+        # Собираем тикеры со stop-сигналом (убыток) и exit-сигналом (прибыль)
+        for flag_prefix in ["stop_", "exit_"]:
+            for flag_file in signals_dir.glob(f"{flag_prefix}*.flag"):
+                ticker = flag_file.stem[len(flag_prefix):]
+                expiry = now_ts + cooldown_sec
+                toxic_blacklist[ticker] = expiry
+                signal_type = "STOP" if flag_prefix == "stop_" else "EXIT"
+                logger.info(f"🚫 {signal_type} signal received for {ticker}. Blacklisted until {time.ctime(expiry)}")
 
-        # Удаляем все прочитанные флаги (stop и exit)
-        for flag_file in signals_dir.glob("stop_*.flag"):
-            try:
-                flag_file.unlink()
-            except Exception:
-                pass
-        for flag_file in signals_dir.glob("exit_*.flag"):
-            try:
-                flag_file.unlink()
-            except Exception:
-                pass
+                try:
+                    flag_file.unlink()
+                except Exception:
+                    pass
 
         # Prune expired entries from toxic_blacklist
         toxic_blacklist = {s: exp for s, exp in toxic_blacklist.items() if exp > now_ts}


### PR DESCRIPTION
This PR fixes a critical bug where profitable bots remained in the `live_swarm` indefinitely after a trailing stop was triggered.

Key changes:
1. **`main.py`**:
   - `_update_final_metrics_for_exit` no longer resets `trailing_stop_triggered` to `False`. This ensures the Supervisor can detect the true cause of the bot's termination.
   - Removed direct writes to `config.json` when a trailing stop is triggered. Instead, the bot emits an `exit` signal, delegating the cleanup and blacklisting logic to the Supervisor to avoid race conditions in a multi-process environment.

2. **`supervisor.py`**:
   - `enforce_swarm_consistency` now checks for the `trailing_stop_triggered` flag in the real state file. If found, it rejects healing the bot and instead schedules position liquidation.
   - `manage_swarm` now processes both `stop_` and `exit_` signals uniformly, adding the corresponding tickers to the `toxic_blacklist` with a cooldown period.

These changes ensure robust bot rotation and prevent "immortal" bots after stop-loss/take-profit events.

---
*PR created automatically by Jules for task [13749269782324688925](https://jules.google.com/task/13749269782324688925) started by @FMProducer*