### PR TITLE
Activate Trailing Stop Flag and Enforce Toxic Blacklist Filter

### DIFF
--- a/futures_portfolio/main.py
+++ b/futures_portfolio/main.py
@@ -936,6 +936,9 @@ async def rebalance_loop(connector: BinanceConnector, config_path: str, state_fi
                                 paper_state["short_entry_price"] = 0.0
                                 await save_json(paper_state_file_path, paper_state)
 
+                                # Жестко фиксируем смерть по трейлингу для HEAL Guard
+                                state["trailing_stop_triggered"] = True
+
                                 # --- CRITICAL: Update final metrics BEFORE state resets and exit ---
                                 await _update_final_metrics_for_exit(state, state_file_path, Decimal(str(tpv_total)), Decimal(str(initial_tpv)), calc_res, cycles, logger)
                                 # --------------------------------------------------------------------

--- a/futures_portfolio/supervisor.py
+++ b/futures_portfolio/supervisor.py
@@ -353,9 +353,13 @@ async def selective_merge_incubator(
         score = _calc_rotation_score(t, p, min_cycles)
         scored_old[t] = score
 
+    # Вычищаем карантинных юнитов из старого пула (строгая изоляция)
+    toxic_blacklist = config.get("toxic_blacklist", {})
+    healthy_old_incubator = [t for t in old_incubator if t not in toxic_blacklist]
+
     # 2. Боты с положительным PnL — ВСЕГДА остаются в рое (не подлежат замене)
-    old_set = set(old_incubator)
-    profitable = {t for t in old_incubator if perf_map.get(t, {}).get("profit", 0) > 0}
+    old_set = set(healthy_old_incubator)
+    profitable = {t for t in healthy_old_incubator if perf_map.get(t, {}).get("profit", 0) > 0}
     # Боты с отрицательным PnL — кандидаты на замену (конкурируют с новыми)
     unprofitable = old_set - profitable
 


### PR DESCRIPTION
This PR implements two fixes:
1. **Fix 1: Flag trailing stop events in `main.py`**
   Added `state["trailing_stop_triggered"] = True` before updating final metrics in the trailing stop logic. This allows monitoring tools like HEAL Guard to distinguish between unexpected process death and a planned stop due to a trailing stop violation.

2. **Fix 2: Enforce toxic blacklist in `supervisor.py`**
   Modified `selective_merge_incubator` to strictly filter out tickers present in the `toxic_blacklist` before processing profitable bots. This ensures that "toxic" tickers are properly quarantined and replaced in the incubator swarm regardless of their current profitability.

---
*PR created automatically by Jules for task [9752958199851249291](https://jules.google.com/task/9752958199851249291) started by @FMProducer*