### PR TITLE
Apply P0 hotfix for B1 (TS flag persistence bug)

### DIFF
--- a/futures_portfolio/main.py
+++ b/futures_portfolio/main.py
@@ -408,6 +408,10 @@ async def rebalance_loop(connector: BinanceConnector, config_path: str, state_fi
                     state['rebalance_cycles'] = 0
                     state['initial_tpv'] = initial_cap
                     state['reference_tpv'] = initial_cap
+                    state['trailing_stop_triggered'] = False
+                    state['trailing_stop_violation_start'] = 0.0
+                    state['trailing_stop_paper_timeout_end'] = 0.0
+                    logger.info(f"🔄 TS flags reset: clean start detected (no open positions)")
                     await save_json(state_file_path, state)
         except Exception as e:
             logger.error(f"State Isolation Protocol failed: {e}")

--- a/futures_portfolio/supervisor.py
+++ b/futures_portfolio/supervisor.py
@@ -125,6 +125,18 @@ async def enforce_swarm_consistency(connector: BinanceConnector, config: dict) -
                     if state_data.get("trailing_stop_triggered", False):
                         logger.warning(f"⚠️ HEAL REJECTED: {ticker} was stopped by Trailing Stop. Scheduling position liquidation.")
                         to_close_tickers.add(ticker)
+
+                        # Сброс TS флагов для будущего чистого старта
+                        try:
+                            state_data["trailing_stop_triggered"] = False
+                            state_data["trailing_stop_violation_start"] = 0.0
+                            state_data["trailing_stop_paper_timeout_end"] = 0.0
+                            with open(state_path, "w", encoding="utf-8") as f:
+                                json.dump(state_data, f, indent=2, ensure_ascii=False)
+                            logger.info(f"🔄 TS flags reset in state file for {ticker}")
+                        except Exception as e:
+                            logger.error(f"Failed to reset TS flags for {ticker}: {e}")
+
                         continue
 
                     logger.warning(f"🚨 HEAL TRIGGERED: Active position for {ticker} detected on exchange, but PM2 process is dead. Real state file is valid. Initiating recovery...")


### PR DESCRIPTION
This hotfix addresses the B1 bug where Trailing Stop flags could persist incorrectly, potentially allowing a bot to run without protection after a restart.

Key changes:
1.  **main.py**: Updated the `State Isolation Protocol` block to reset `trailing_stop_triggered`, `trailing_stop_violation_start`, and `trailing_stop_paper_timeout_end` whenever a clean start is detected (i.e., no open positions on the exchange).
2.  **supervisor.py**: Enhanced the `HEAL REJECTED` logic in `enforce_swarm_consistency`. When a bot's recovery is rejected because a Trailing Stop was previously triggered, the relevant TS flags are now reset in its state file. This ensures that if the bot is manually restarted later with a clean state, it starts with fresh TS tracking.

These changes ensure the integrity of the Trailing Stop mechanism across bot restarts and supervisor-led recoveries.

---
*PR created automatically by Jules for task [2091371157549725462](https://jules.google.com/task/2091371157549725462) started by @FMProducer*