### PR TITLE
Prevent PM2 restart loop and ensure signals directory exists

### DIFF
--- a/futures_portfolio/main.py
+++ b/futures_portfolio/main.py
@@ -31,7 +31,9 @@ def sync_read_json(path: str) -> Dict:
 
 def emit_signal(signal_type: str, ticker: str) -> None:
     """Создает пустой файл-флаг для супервайзера."""
-    sig_path = Path("signals") / f"{signal_type}_{ticker}.flag"
+    sig_dir = Path("signals")
+    sig_dir.mkdir(exist_ok=True)
+    sig_path = sig_dir / f"{signal_type}_{ticker}.flag"
     try:
         sig_path.touch(exist_ok=True)
     except Exception as e:
@@ -498,8 +500,8 @@ async def rebalance_loop(connector: BinanceConnector, config_path: str, state_fi
             try:
                 # Failsafe: if restarted by PM2 with triggered state, exit immediately
                 if state.get("trailing_stop_triggered", False):
-                    logger.critical(f"🚨 Trailing Stop already triggered for {base_ticker}. Terminal exit to prevent race condition.")
-                    sys.exit(0)
+                    logger.critical(f"🚨 Trailing Stop already triggered for {base_ticker}. Entering deep sleep to prevent PM2 restart loop.")
+                    while True: await asyncio.sleep(86400)
 
                 # Dynamic config reload
                 try:
@@ -883,7 +885,7 @@ async def rebalance_loop(connector: BinanceConnector, config_path: str, state_fi
                     await _update_final_metrics_for_exit(state, state_file_path, Decimal(str(tpv_total)), Decimal(str(initial_tpv)), calc_res, cycles, logger)
                     # --------------------------------------------------------------------
                     await emergency_stop(connector, config_path, state_file_path, paper_state_file_path, logger, ticker_override=base_ticker, paper_mode=paper_mode, close_only=True)
-                    sys.exit(0)
+                    while True: await asyncio.sleep(86400)
 
                 if tpv_ath == 0 or tpv_total > tpv_ath:
                     tpv_ath = tpv_total
@@ -936,7 +938,7 @@ async def rebalance_loop(connector: BinanceConnector, config_path: str, state_fi
                                 logger.critical(f"Initiating synchronous emergency liquidation for {base_ticker}...")
                                 # Close positions on exchange, preserve internal state for supervisor review
                                 await emergency_stop(connector, config_path, state_file_path, paper_state_file_path, logger, ticker_override=base_ticker, paper_mode=paper_mode, close_only=True)
-                                sys.exit(0)
+                                while True: await asyncio.sleep(86400)
                             else:
                                 # Timeout not yet reached — still pending
                                 if i % 5 == 0:
@@ -949,8 +951,8 @@ async def rebalance_loop(connector: BinanceConnector, config_path: str, state_fi
 
                 # Check if trailing stop was previously triggered (one-shot)
                 if state.get("trailing_stop_triggered", False):
-                    logger.critical(f"🚨 Trailing Stop already triggered for {base_ticker}. Terminal exit to prevent race condition.")
-                    sys.exit(0) # Failsafe: if restarted by PM2 with triggered state, exit immediately
+                    logger.critical(f"🚨 Trailing Stop already triggered for {base_ticker}. Entering deep sleep to prevent PM2 restart loop.")
+                    while True: await asyncio.sleep(86400)
 
                 if not paper_mode and (margin_warning > 0 or margin_critical > 0):
                     try:
@@ -965,7 +967,7 @@ async def rebalance_loop(connector: BinanceConnector, config_path: str, state_fi
                                 await _update_final_metrics_for_exit(state, state_file_path, Decimal(str(tpv_total)), Decimal(str(initial_tpv)), calc_res, cycles, logger)
                                 # --------------------------------------------------------------------
                                 await emergency_stop(connector, config_path, state_file_path, paper_state_file_path, logger, ticker_override=base_ticker, paper_mode=paper_mode, close_only=True)
-                                sys.exit(0)
+                                while True: await asyncio.sleep(86400)
                             elif m_ratio < portfolio_cfg.get("margin_ratio_warning", 5.0):
                                 msg = f"Low margin ratio: {m_ratio:.2f}"
                                 logger.warning(msg)
@@ -1319,13 +1321,13 @@ async def rebalance_loop(connector: BinanceConnector, config_path: str, state_fi
                             await _handle_liquidation_recovery(connector, base_ticker, state, state_file_path,
                                                                 paper_state, paper_state_file_path,
                                                                 config_path, logger, notifier)
-                            sys.exit(0)
+                            while True: await asyncio.sleep(86400)
                         if expected_short != 0 and not has_short:
                             logger.error(f"🚨 LIQUIDATION DETECTED: {base_ticker}_SHORT is MISSING on exchange!")
                             await _handle_liquidation_recovery(connector, base_ticker, state, state_file_path,
                                                                 paper_state, paper_state_file_path,
                                                                 config_path, logger, notifier)
-                            sys.exit(0)
+                            while True: await asyncio.sleep(86400)
                     except Exception as e:
                         logger.warning(f"Liquidation guard check failed: {e}")
 


### PR DESCRIPTION
This change addresses a 'bounce loop' issue where PM2 repeatedly restarts a bot process that has reached a terminal state (e.g., trailing stop triggered). By replacing `sys.exit(0)` with an infinite asynchronous sleep, the process remains alive but dormant, allowing the supervisor to manage its lifecycle without PM2 interference. Additionally, the `emit_signal` function now ensures the `signals/` directory exists, improving reliability in clean environments.

---
*PR created automatically by Jules for task [1346073167859197920](https://jules.google.com/task/1346073167859197920) started by @FMProducer*