### PR TITLE
Restore Toxic Blacklist Isolation and Fix Trailing Stop Restarts

### DIFF
--- a/futures_portfolio/main.py
+++ b/futures_portfolio/main.py
@@ -130,13 +130,13 @@ async def _handle_liquidation_recovery(connector, base_ticker, state, state_file
                 if base_ticker in live_swarm:
                     live_swarm.remove(base_ticker)
                     cfg_data["live_swarm"] = live_swarm
-                toxic = cfg_data.get("toxic_blacklist", {})
+                toxic = cfg_data.get("toxic_blacklist_real", {})
                 cooldown_days = cfg_data.get("toxic_cooldown_days", 0.02)
                 expiry = time.time() + cooldown_days * 86400
                 toxic[base_ticker] = expiry
-                cfg_data["toxic_blacklist"] = toxic
+                cfg_data["toxic_blacklist_real"] = toxic
                 cfg_path.write_text(_json.dumps(cfg_data, indent=2, ensure_ascii=False))
-                logger.info(f"{base_ticker} removed from live_swarm, added to toxic_blacklist")
+                logger.info(f"{base_ticker} removed from live_swarm, added to toxic_blacklist_real")
         except Exception as e:
             logger.error(f"Failed to update config: {e}")
 
@@ -238,12 +238,13 @@ async def _handle_liquidation_guard(
                 if base_ticker not in bl:
                     bl.append(base_ticker)
                     cfg_data["black_list"] = bl
-                # Also add to toxic_blacklist with cooldown
-                toxic = cfg_data.get("toxic_blacklist", {})
+                # Also add to isolated toxic_blacklist with cooldown
+                bl_key = "toxic_blacklist_paper" if is_paper else "toxic_blacklist_real"
+                toxic = cfg_data.get(bl_key, {})
                 cooldown_days = cfg_data.get("toxic_cooldown_days", 0.02)
                 expiry = time.time() + cooldown_days * 86400
                 toxic[base_ticker] = expiry
-                cfg_data["toxic_blacklist"] = toxic
+                cfg_data[bl_key] = toxic
                 # Remove from live_swarm
                 live_swarm = cfg_data.get("live_swarm", [])
                 if base_ticker in live_swarm:
@@ -1510,8 +1511,7 @@ async def emergency_stop(connector: BinanceConnector, config_path: str, state_fi
                         "initial_tpv": current_tpv,
                         "reference_tpv": current_tpv,
                         "tpv_ath": current_tpv,
-                        "trailing_stop_violation_start": 0.0,
-                        "trailing_stop_triggered": False
+                        "trailing_stop_violation_start": 0.0
                     })
                     await save_json(state_file_path, state)
         except Exception as e:

--- a/futures_portfolio/supervisor.py
+++ b/futures_portfolio/supervisor.py
@@ -621,6 +621,11 @@ async def manage_swarm():
     current_real_tickers = [k.replace("r_", "") for k in running_bots.keys() if k.startswith("r_")]
     # Объединяем с только что восстановленными ботами для компенсации задержки старта PM2
     current_real_tickers = list(set(current_real_tickers).union(healed_tickers))
+
+    # [FIX] Удаляем карантинных ботов из пула "текущих", чтобы они не попали в target_real_bots
+    bl_real = config.get("toxic_blacklist_real", {})
+    current_real_tickers = [t for t in current_real_tickers if t not in bl_real]
+
     all_evaluated_tickers = set(final_incubator).union(current_real_tickers)
 
     missing_tickers = [t for t in all_evaluated_tickers if t not in global_perf_map]
@@ -644,6 +649,11 @@ async def manage_swarm():
         # Whitelist check
         if use_whitelist and ticker not in real_whitelist and ticker not in current_real_tickers:
             logger.info(f"🚫 Skipping {ticker}: Not in real_whitelist and not a currently running real bot.")
+            continue
+
+        # Strict Blacklist Guard
+        if ticker in bl_real:
+            logger.info(f"🚫 Skipping {ticker}: In REAL toxic blacklist. Quarantined.")
             continue
 
         # 1. Fetch data
@@ -697,7 +707,8 @@ async def manage_swarm():
     max_real_slots = max(0, config.get("max_bots", 10) - config.get("paper_mode_bots", 9))
 
     # Sophisticated substitution logic: hysteresis, profit protection, and score cushion
-    current_real_tickers = [k.replace("r_", "") for k in running_bots.keys() if k.startswith("r_")]
+    # current_real_tickers is already strictly filtered from bl_real above
+    # current_real_tickers = [k.replace("r_", "") for k in running_bots.keys() if k.startswith("r_")]
 
     # 1. Start with currently running bots
     target_real_bots = list(current_real_tickers)


### PR DESCRIPTION
This submission applies critical fixes to `futures_portfolio/main.py` and `futures_portfolio/supervisor.py` to restore the isolation between real and paper toxic blacklists and to prevent bots from cyclically restarting after a Trailing Stop event.

Key changes:
1. **Blacklist Isolation**: In `main.py`, functions like `_handle_liquidation_recovery` and `_handle_liquidation_guard` now correctly use `toxic_blacklist_real` and `toxic_blacklist_paper` based on the bot's mode.
2. **Restart Prevention**: In `main.py`'s `emergency_stop` function, the `trailing_stop_triggered` flag is no longer reset to `False` during sanitation. This ensures the flag persists, allowing the Supervisor's Reaper Guard to identify stopped bots and preventing them from being immediately relaunched.
3. **Supervisor Guards**: In `supervisor.py`, `current_real_tickers` are filtered against `toxic_blacklist_real` early in the `manage_swarm` loop. A strict blacklist guard was also added to the ticker evaluation cycle to skip quarantined assets. Redundant recalculations of the ticker pool were removed/commented out to maintain the filtered state.

Tests were run and confirmed that these changes correctly manage bot state and environment isolation.

---
*PR created automatically by Jules for task [13913253904145019311](https://jules.google.com/task/13913253904145019311) started by @FMProducer*