### PR TITLE
Fix PM2 restart loop with Zombie Mode implementation

### DIFF
--- a/futures_portfolio/main.py
+++ b/futures_portfolio/main.py
@@ -542,9 +542,10 @@ async def rebalance_loop(connector: BinanceConnector, config_path: str, state_fi
             try:
                 # Failsafe: if restarted by PM2 with triggered state, exit immediately to trigger Reaper
                 if state.get("trailing_stop_triggered", False):
-                    logger.critical(f"🚨 Trailing Stop already triggered for {base_ticker}. Exiting process.")
+                    logger.critical(f"🚨 Trailing Stop already triggered for {base_ticker}. Entering Zombie Mode.")
                     self_kill_pm2(base_ticker, paper_mode)
-                    sys.exit(0)
+                    while True:
+                        await asyncio.sleep(86400)
 
                 # Dynamic config reload
                 try:
@@ -953,7 +954,8 @@ async def rebalance_loop(connector: BinanceConnector, config_path: str, state_fi
                     # --------------------------------------------------------------------
                     await emergency_stop(connector, config_path, state_file_path, paper_state_file_path, logger, ticker_override=base_ticker, paper_mode=paper_mode, close_only=True)
                     self_kill_pm2(base_ticker, paper_mode)
-                    sys.exit(0)
+                    while True:
+                        await asyncio.sleep(86400)
 
                 if tpv_ath == 0 or tpv_total > tpv_ath:
                     tpv_ath = tpv_total
@@ -1053,7 +1055,8 @@ async def rebalance_loop(connector: BinanceConnector, config_path: str, state_fi
                                 # Close positions on exchange, preserve internal state for supervisor review
                                 await emergency_stop(connector, config_path, state_file_path, paper_state_file_path, logger, ticker_override=base_ticker, paper_mode=paper_mode, close_only=True)
                                 self_kill_pm2(base_ticker, paper_mode)
-                                sys.exit(0)
+                                while True:
+                                    await asyncio.sleep(86400)
                             else:
                                 # Timeout not yet reached — still pending
                                 if i % 5 == 0:
@@ -1066,9 +1069,10 @@ async def rebalance_loop(connector: BinanceConnector, config_path: str, state_fi
 
                 # Check if trailing stop was previously triggered (one-shot)
                 if state.get("trailing_stop_triggered", False):
-                    logger.critical(f"🚨 Trailing Stop already triggered for {base_ticker}. Exiting process.")
+                    logger.critical(f"🚨 Trailing Stop already triggered for {base_ticker}. Entering Zombie Mode.")
                     self_kill_pm2(base_ticker, paper_mode)
-                    sys.exit(0)
+                    while True:
+                        await asyncio.sleep(86400)
 
                 if not paper_mode and (margin_warning > 0 or margin_critical > 0):
                     try:
@@ -1083,7 +1087,8 @@ async def rebalance_loop(connector: BinanceConnector, config_path: str, state_fi
                                 await _update_final_metrics_for_exit(state, state_file_path, Decimal(str(tpv_total)), Decimal(str(initial_tpv)), calc_res, cycles, logger)
                                 # --------------------------------------------------------------------
                                 await emergency_stop(connector, config_path, state_file_path, paper_state_file_path, logger, ticker_override=base_ticker, paper_mode=paper_mode, close_only=True)
-                                sys.exit(0)
+                                while True:
+                                    await asyncio.sleep(86400)
                             elif m_ratio < portfolio_cfg.get("margin_ratio_warning", 5.0):
                                 msg = f"Low margin ratio: {m_ratio:.2f}"
                                 logger.warning(msg)
@@ -1437,13 +1442,15 @@ async def rebalance_loop(connector: BinanceConnector, config_path: str, state_fi
                             await _handle_liquidation_recovery(connector, base_ticker, state, state_file_path,
                                                                 paper_state, paper_state_file_path,
                                                                 config_path, logger, notifier)
-                            sys.exit(0)
+                            while True:
+                                await asyncio.sleep(86400)
                         if expected_short != 0 and not has_short:
                             logger.error(f"🚨 LIQUIDATION DETECTED: {base_ticker}_SHORT is MISSING on exchange!")
                             await _handle_liquidation_recovery(connector, base_ticker, state, state_file_path,
                                                                 paper_state, paper_state_file_path,
                                                                 config_path, logger, notifier)
-                            sys.exit(0)
+                            while True:
+                                await asyncio.sleep(86400)
                     except Exception as e:
                         logger.warning(f"Liquidation guard check failed: {e}")
 
@@ -1665,6 +1672,14 @@ if __name__ == "__main__":
     
     api_key = os.environ.get("BINANCE_API_KEY", cfg.get("api_key", ""))
     secret_key = os.environ.get("BINANCE_SECRET_KEY", cfg.get("secret_key", ""))
+
+    # [Hardware Block] Zombie Mode to prevent PM2 autorestart loop and API spam
+    pre_state = safe_load_json_sync(instance_state_file, {})
+    if pre_state.get("trailing_stop_triggered", False) and not args.stop and not args.wipe:
+        logger.critical(f"🚨 [ZOMBIE MODE] Trailing Stop triggered for {base_ticker}. Entering infinite sleep to block PM2 autorestart.")
+        import time
+        while True:
+            time.sleep(86400)
 
     if os.environ.get("MOCK_MODE") == "1":
         from connector import BinanceConnectorMock

--- a/futures_portfolio/tests/test_main.py
+++ b/futures_portfolio/tests/test_main.py
@@ -1,3 +1,6 @@
+class ZombieExit(BaseException):
+    pass
+
 import pytest
 import json
 import os
@@ -61,6 +64,11 @@ def mock_notifier():
     notifier.close = AsyncMock()
     return notifier
 
+def sleep_side_effect(secs, *args):
+    if secs == 86400:
+        raise ZombieExit("ZombieMode")
+    return None
+
 @pytest.mark.asyncio
 async def test_rebalance_loop_siphoning(mock_config, mock_connector, mock_notifier):
     state = {
@@ -92,18 +100,25 @@ async def test_rebalance_loop_siphoning(mock_config, mock_connector, mock_notifi
 
     mock_config["portfolios"][0]["max_capital_usdt"] = 0.0
 
-    with patch("builtins.open", mock_open(read_data=json.dumps(mock_config))), \
-         patch("futures_portfolio.main.safe_load_json_sync", return_value=mock_config), \
-         patch("os.path.getmtime", return_value=123):
+    # We want to stop the loop after a few iterations
+    loop_count = 0
+    def bounded_sleep(secs, *args):
+        nonlocal loop_count
+        if secs == 86400: raise ZombieExit("ZombieMode")
+        loop_count += 1
+        if loop_count > 5: raise Exception("StopLoop")
+        return None
+
+    with patch("builtins.open", mock_open(read_data=json.dumps(mock_config))),          patch("futures_portfolio.main.safe_load_json_sync", return_value=mock_config),          patch("os.path.getmtime", return_value=123):
         with patch("futures_portfolio.main.load_json", AsyncMock(side_effect=load_side_effect)):
             with patch("futures_portfolio.main.save_json", AsyncMock(side_effect=save_side_effect)):
                 with patch("futures_portfolio.main.sys.exit", side_effect=BaseException("ProcessExit")):
-                    with patch("asyncio.sleep", side_effect=[None, None, Exception("StopLoop")]):
+                    with patch("asyncio.sleep", side_effect=bounded_sleep):
                             with patch("futures_portfolio.main.TelegramNotifier", return_value=mock_notifier):
                                 try:
                                     await rebalance_loop(mock_connector, "config.json", "state.json", "paper_state.json", MagicMock())
                                 except (Exception, BaseException) as e:
-                                    if str(e) not in ["StopLoop", "ProcessExit"]: raise e
+                                    if str(e) not in ["StopLoop", "ProcessExit", "ZombieMode"]: raise e
     assert len(saves) > 0
 
 @pytest.mark.asyncio
@@ -136,18 +151,16 @@ async def test_rebalance_loop_trailing_stop(mock_config, mock_connector, mock_no
     def save_side_effect(path, data):
         saves.append((path, copy.deepcopy(data)))
 
-    with patch("builtins.open", mock_open(read_data=json.dumps(mock_config))), \
-         patch("futures_portfolio.main.safe_load_json_sync", return_value=mock_config), \
-         patch("os.path.getmtime", return_value=123):
+    with patch("builtins.open", mock_open(read_data=json.dumps(mock_config))),          patch("futures_portfolio.main.safe_load_json_sync", return_value=mock_config),          patch("os.path.getmtime", return_value=123):
         with patch("futures_portfolio.main.load_json", AsyncMock(side_effect=load_side_effect)):
             with patch("futures_portfolio.main.save_json", AsyncMock(side_effect=save_side_effect)):
                 with patch("futures_portfolio.main.sys.exit", side_effect=BaseException("ProcessExit")):
                     with patch("futures_portfolio.main.TelegramNotifier", return_value=mock_notifier):
-                            with patch("asyncio.sleep", side_effect=[None, None, None, Exception("StopLoop")]):
+                            with patch("asyncio.sleep", side_effect=sleep_side_effect):
                                 try:
                                         await rebalance_loop(mock_connector, "config.json", "state.json", "paper_state.json", MagicMock())
                                 except (Exception, BaseException) as e:
-                                    if str(e) not in ["StopLoop", "ProcessExit"]: raise e
+                                    if str(e) not in ["StopLoop", "ProcessExit", "ZombieMode"]: raise e
 
     # Check if any paper_state save has 0 positions
     reset_save = next((s[1] for s in saves if "paper_state" in s[0] and s[1]["positions"].get("BTCUSDT_LONG") == 0.0), None)
@@ -164,18 +177,24 @@ async def test_rebalance_loop_margin_warning(mock_config, mock_connector, mock_n
         if "s.json" in path: return copy.deepcopy(state)
         return default
 
-    with patch("builtins.open", mock_open(read_data=json.dumps(mock_config))), \
-         patch("futures_portfolio.main.safe_load_json_sync", return_value=mock_config), \
-         patch("os.path.getmtime", return_value=123):
+    loop_count = 0
+    def bounded_sleep(secs, *args):
+        nonlocal loop_count
+        if secs == 86400: raise ZombieExit("ZombieMode")
+        loop_count += 1
+        if loop_count > 5: raise Exception("StopLoop")
+        return None
+
+    with patch("builtins.open", mock_open(read_data=json.dumps(mock_config))),          patch("futures_portfolio.main.safe_load_json_sync", return_value=mock_config),          patch("os.path.getmtime", return_value=123):
         with patch("futures_portfolio.main.load_json", AsyncMock(side_effect=load_side_effect)):
             with patch("futures_portfolio.main.save_json", AsyncMock()):
                 with patch("futures_portfolio.main.sys.exit", side_effect=BaseException("ProcessExit")):
-                    with patch("asyncio.sleep", side_effect=[None, None, None, Exception("StopLoop")]):
+                    with patch("asyncio.sleep", side_effect=bounded_sleep):
                             with patch("futures_portfolio.main.TelegramNotifier", return_value=mock_notifier):
                                 try:
                                     await rebalance_loop(mock_connector, "c.json", "s.json", "p.json", MagicMock())
                                 except (Exception, BaseException) as e:
-                                    if str(e) not in ["StopLoop", "ProcessExit"]: raise e
+                                    if str(e) not in ["StopLoop", "ProcessExit", "ZombieMode"]: raise e
     mock_notifier.send_message.assert_any_call("⚠️ <b>WARNING</b>: Low margin ratio: 3.00 (BTCUSDT)")
 
 @pytest.mark.asyncio
@@ -189,18 +208,16 @@ async def test_rebalance_loop_margin_critical(mock_config, mock_connector, mock_
         if "s.json" in path: return copy.deepcopy(state)
         return default
 
-    with patch("builtins.open", mock_open(read_data=json.dumps(mock_config))), \
-         patch("futures_portfolio.main.safe_load_json_sync", return_value=mock_config), \
-         patch("os.path.getmtime", return_value=123):
+    with patch("builtins.open", mock_open(read_data=json.dumps(mock_config))),          patch("futures_portfolio.main.safe_load_json_sync", return_value=mock_config),          patch("os.path.getmtime", return_value=123):
         with patch("futures_portfolio.main.load_json", AsyncMock(side_effect=load_side_effect)):
             with patch("futures_portfolio.main.save_json", AsyncMock()):
                 with patch("futures_portfolio.main.sys.exit", side_effect=BaseException("ProcessExit")):
-                    with patch("asyncio.sleep", side_effect=[None, None, Exception("StopLoop")]):
+                    with patch("asyncio.sleep", side_effect=sleep_side_effect):
                             with patch("futures_portfolio.main.TelegramNotifier", return_value=mock_notifier):
                                 try:
                                     await rebalance_loop(mock_connector, "c.json", "s.json", "p.json", MagicMock())
                                 except (Exception, BaseException) as e:
-                                    if str(e) not in ["StopLoop", "ProcessExit"]: raise e
+                                    if str(e) not in ["StopLoop", "ProcessExit", "ZombieMode"]: raise e
     mock_notifier.send_alert.assert_called_with("CRITICAL MARGIN", "Margin ratio 1.50 < 2.0. Emergency stop!")
 
 @pytest.mark.asyncio
@@ -232,18 +249,24 @@ async def test_clean_slate_protocol_activation(mock_config, mock_connector, mock
     def save_side_effect(path, data):
         saves.append((path, copy.deepcopy(data)))
 
-    with patch("builtins.open", mock_open(read_data=json.dumps(mock_config))), \
-         patch("futures_portfolio.main.safe_load_json_sync", return_value=mock_config), \
-         patch("os.path.getmtime", return_value=123):
+    loop_count = 0
+    def bounded_sleep(secs, *args):
+        nonlocal loop_count
+        if secs == 86400: raise ZombieExit("ZombieMode")
+        loop_count += 1
+        if loop_count > 1: raise Exception("StopLoop")
+        return None
+
+    with patch("builtins.open", mock_open(read_data=json.dumps(mock_config))),          patch("futures_portfolio.main.safe_load_json_sync", return_value=mock_config),          patch("os.path.getmtime", return_value=123):
         with patch("futures_portfolio.main.load_json", AsyncMock(side_effect=load_side_effect)):
             with patch("futures_portfolio.main.save_json", AsyncMock(side_effect=save_side_effect)):
                 with patch("futures_portfolio.main.sys.exit", side_effect=BaseException("ProcessExit")):
-                    with patch("asyncio.sleep", side_effect=Exception("StopLoop")):
+                    with patch("asyncio.sleep", side_effect=bounded_sleep):
                             with patch("futures_portfolio.main.TelegramNotifier", return_value=mock_notifier):
                                 try:
                                     await rebalance_loop(mock_connector, "c.json", "s.json", "p.json", MagicMock())
                                 except (Exception, BaseException) as e:
-                                    if str(e) not in ["StopLoop", "ProcessExit"]: raise e
+                                    if str(e) not in ["StopLoop", "ProcessExit", "ZombieMode"]: raise e
 
     # Check if a save happened with reset values (the protocol saves them immediately)
     reset_state_save = next((s[1] for s in saves if "s.json" in s[0] and s[1]["tpv_ath"] == 100.0), None)


### PR DESCRIPTION
This PR implements a "Zombie Mode" pattern in the trading bot to address an issue where PM2 enters an uncontrolled autorestart loop after a Trailing Stop is triggered. 

Currently, the bot uses `sys.exit(0)` which PM2 interprets as a successful completion and immediately restarts the process. If `self_kill_pm2` fails (e.g., due to PATH issues), this leads to infinite re-initialization and API spam.

**Changes:**
1. **Global Entry Block:** In `main.py`, the script now checks the state file *before* initializing Binance API connectors. If `trailing_stop_triggered` is true, it enters an infinite `time.sleep(86400)` loop.
2. **Cycle Exit replacement:** All instances of `sys.exit(0)` within the `rebalance_loop` (Trailing Stop, Max Drawdown, Critical Margin, Liquidation) are replaced with a non-blocking `while True: await asyncio.sleep(86400)`.
3. **Test Suite Compatibility:** Updated `futures_portfolio/tests/test_main.py` to support this new behavior. Tests now mock `asyncio.sleep` and raise a `ZombieExit` exception when the "infinite" sleep duration is detected, allowing them to verify that the terminal state was reached correctly without hanging the test runner.

This hardware-level block effectively stops the bot from spamming the exchange after a terminal event while preserving the state flag for the Supervisor's Reaper Guard cleanup.

---
*PR created automatically by Jules for task [15761162105941321873](https://jules.google.com/task/15761162105941321873) started by @FMProducer*